### PR TITLE
Key#isTab is false if a modifier key is pressed

### DIFF
--- a/src/js/utils/key.js
+++ b/src/js/utils/key.js
@@ -141,8 +141,14 @@ const Key = class Key {
     return this.keyCode === Keycodes.SPACE;
   }
 
+  // In Firefox, pressing ctrl-TAB will switch to another open browser tab, but it will
+  // also fire a keydown event for the tab+modifier (ctrl). This causes Mobiledoc
+  // to erroneously insert a tab character before FF switches to the new browser tab.
+  // Chrome doesn't fire this event so the issue doesn't arise there.
+  // Fix this by returning false when the TAB key event includes a modifier.
+  // See: https://github.com/bustle/mobiledoc-kit/issues/565
   isTab() {
-    return this.keyCode === Keycodes.TAB;
+    return !this.hasAnyModifier() && this.keyCode === Keycodes.TAB;
   }
 
   isEnter() {

--- a/tests/acceptance/editor-input-handlers-test.js
+++ b/tests/acceptance/editor-input-handlers-test.js
@@ -2,6 +2,7 @@ import Helpers from '../test-helpers';
 import Range from 'mobiledoc-kit/utils/cursor/range';
 import { NO_BREAK_SPACE } from 'mobiledoc-kit/renderers/editor-dom';
 import { TAB } from 'mobiledoc-kit/utils/characters';
+import { MODIFIERS }  from 'mobiledoc-kit/utils/key';
 
 const { module, test } = Helpers;
 const { editor: { buildFromText } } = Helpers;
@@ -298,6 +299,15 @@ test('input handler can be triggered by TAB', (assert) => {
   Helpers.dom.insertText(editor, TAB);
 
   assert.ok(didMatch);
+});
+
+// See https://github.com/bustle/mobiledoc-kit/issues/565
+test('typing ctrl-TAB does not insert TAB text', (assert) => {
+  editor = Helpers.editor.buildFromText('abc|', {element: editorElement});
+
+  Helpers.dom.triggerKeyCommand(editor, TAB, [MODIFIERS.CTRL]);
+
+  assert.equal(editorElement.textContent, 'abc', 'no TAB is inserted');
 });
 
 test('can unregister all handlers', (assert) => {


### PR DESCRIPTION
Fixes #565 

Paired with @YoranBrondsema to make these changes. 👍 