### PR TITLE
Hide link tooltip if that link is toggled off

### DIFF
--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -66,6 +66,20 @@ function setData(element, name, value) {
   }
 }
 
+function whenElementIsNotInDOM(element, callback) {
+  let isCanceled = false;
+  const observerFn = () => {
+    if (isCanceled) { return; }
+    if (!element.parentNode) {
+      callback();
+    } else {
+      window.requestAnimationFrame(observerFn);
+    }
+  };
+  observerFn();
+  return { cancel: () => isCanceled = true };
+}
+
 export {
   setData,
   getEventTargetMatchingTag,
@@ -73,5 +87,6 @@ export {
   getElementComputedStyleNumericProp,
   positionElementToRect,
   positionElementHorizontallyCenteredToRect,
-  positionElementCenteredBelow
+  positionElementCenteredBelow,
+  whenElementIsNotInDOM
 };

--- a/src/js/views/tooltip.js
+++ b/src/js/views/tooltip.js
@@ -1,5 +1,9 @@
 import View from './view';
-import { positionElementCenteredBelow, getEventTargetMatchingTag } from '../utils/element-utils';
+import {
+  positionElementCenteredBelow,
+  getEventTargetMatchingTag,
+  whenElementIsNotInDOM
+} from '../utils/element-utils';
 
 const DELAY = 200;
 
@@ -21,6 +25,7 @@ export default class Tooltip extends View {
     
     this.addEventListener(rootElement, 'mouseout', (e) => {
       clearTimeout(timeout);
+      if (this.elementObserver) { this.elementObserver.cancel(); }
       let toElement = e.toElement || e.relatedTarget;
       if (toElement && toElement.className !== this.element.className) {
         this.hide();
@@ -38,5 +43,6 @@ export default class Tooltip extends View {
   showLink(link, element) {
     let message = `<a href="${link}" target="_blank">${link}</a>`;
     this.showMessage(message, element);
+    this.elementObserver = whenElementIsNotInDOM(element, () => this.hide());
   }
 }


### PR DESCRIPTION
Small enhancement. Before this change: when the link tooltip was shown while the "a" link markup is untoggled, the tooltip stays displayed until the mouse moves. This makes the tooltip hide as soon as the `<a>` tag is removed from the dom.

Animation showing the old behavior:
![bug](https://user-images.githubusercontent.com/2023/29191149-c0c61242-7dea-11e7-9740-d1e231c469c2.gif)
