### PR TITLE
Fix for issue #581

### DIFF
--- a/src/js/utils/key.js
+++ b/src/js/utils/key.js
@@ -79,8 +79,7 @@ const Key = class Key {
     if (this.isTab()) { return TAB; }
     return String.fromCharCode(this.charCode);
   }
-
-  isEscape() {
+isEscape() {
     return this.keyCode === Keycodes.ESC;
   }
 
@@ -125,7 +124,10 @@ const Key = class Key {
   }
 
   isEnd() {
-    return this.keyCode === Keycodes.END;
+    return (
+      this.keyCode === Keycodes.END &&
+      !this.modifierMask
+    );
   }
 
   isPageUp() {
@@ -241,11 +243,7 @@ const Key = class Key {
 
   isPrintableKey() {
     return !(
-      this.isArrow() ||
-      this.isHome() || this.isEnd() ||
-      this.isPageUp() || this.isPageDown() ||
-      this.isInsert() || this.isClear() || this.isPause() ||
-      this.isEscape()
+      this.isArrow()
     );
   }
 

--- a/src/js/utils/key.js
+++ b/src/js/utils/key.js
@@ -79,7 +79,8 @@ const Key = class Key {
     if (this.isTab()) { return TAB; }
     return String.fromCharCode(this.charCode);
   }
-isEscape() {
+
+  isEscape() {
     return this.keyCode === Keycodes.ESC;
   }
 

--- a/tests/unit/utils/key-test.js
+++ b/tests/unit/utils/key-test.js
@@ -46,15 +46,7 @@ test('#hasModifier with SHIFT', (assert) => {
 // Firefox will fire keypress events for some keys that should not be printable
 test('firefox: non-printable are treated as not printable', (assert) => {
   const KEYCODES = [
-    Keycodes.DOWN,
-    Keycodes.HOME,
-    Keycodes.END,
-    Keycodes.PAGEUP,
-    Keycodes.PAGEDOWN,
-    Keycodes.INS,
-    Keycodes.CLEAR,
-    Keycodes.PAUSE,
-    Keycodes.ESC
+    Keycodes.DOWN
   ];
 
   KEYCODES.forEach((keyCode) => {


### PR DESCRIPTION

It turns out that `keyCode` is not the right way for uniquely identifying keys. For instance, `End` has a keycode of 35 but so does `Shift+3` (to make the character `#`).

This reverts changes by PR #575  but I suggest that we try to move to a more robust system for uniquely detecting keys. The changes by PR #575 only affected Firefox so I think we can safely use [KeyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) at those locations. For the `End` key, `event.key === 'End'` and for `#`, it's `event.key === '#'`.

Maybe it's an idea to use `event.key` when available (I'm guessing it will be `undefined` for older browsers) and fall back on `event.keyCode`?

Curious to know what you think @bantic .