### PR TITLE
fix(docs): incorrect Marker definition signature

### DIFF
--- a/MOBILEDOC.md
+++ b/MOBILEDOC.md
@@ -141,8 +141,8 @@ The text of a document is held in markers which signal where markup and atoms ap
       [0, [0], 1, "Example wrapped in b tag (opened markup #0), 1 closed markup"],
       [0, [1], 0, "Example opening i tag (opened markup with #1, 0 closed markups)"],
       [0, [], 1, "Example closing i tag (no opened markups, 1 closed markup)"],
-      [0, [1, 0], 1, "Example opening i tag and b tag, closing b tag (opened markups #1 and #0, 1 closed markup [closes markup #1])"],
-      [0, [], 1, "Example closing b tag, (no opened markups, 1 closed markup [closes markup #0])"],
+      [0, [1, 0], 1, "Example opening i tag and b tag, closing b tag (opened markups #1 and #0, 1 closed markup [closes markup #0])"],
+      [0, [], 1, "Example closing i tag, (no opened markups, 1 closed markup [closes markup #1])"],
     ]],
     [1, "p", [
       [textTypeIdentifier, openMarkupsIndexes, numberOfClosedMarkups, atomIndex],
@@ -287,7 +287,7 @@ List similar to markup sections but have a set of markers for each list item.
   ]
   sections: [
     [sectionTypeIdentifier, tagName, [markers, markers, markers]],
-    [3, "ol", [ 
+    [3, "ol", [
       [
         [0, [], 0, "Plain"]
       ],


### PR DESCRIPTION
The text and example didn't seem to match.