### PR TITLE
Fix issue #592: Selection is off when triple-clicking on Firefox

### DIFF
--- a/src/js/utils/cursor/position.js
+++ b/src/js/utils/cursor/position.js
@@ -409,6 +409,12 @@ Position = class Position {
             sectionOffset += postNode.length;
           }
           position = new Position(section, sectionOffset);
+        } else if (offset >= elementNode.childNodes.length) {
+
+          // This is to deal with how Firefox handles triple-click selections.
+          // See https://stackoverflow.com/a/21234837/1269194 for an
+          // explanation.
+          position = section.tailPosition();
         } else {
           // The offset is 0 if the cursor is on a non-atom-wrapper element node
           // (e.g., a <br> tag in a blank markup section)

--- a/tests/unit/utils/cursor-position-test.js
+++ b/tests/unit/utils/cursor-position-test.js
@@ -413,6 +413,40 @@ test('#fromNode when node is root element and offset is > 0', (assert) => {
   assert.positionIsEqual(position, editor.post.tailPosition());
 });
 
+/**
+ * On Firefox, triple-clicking results in a different selection that on Chrome
+ * and others. Imagine we have the following content:
+ *
+ * <p>abc</p>
+ *
+ * Chrome:
+ * anchorNode: <TextNode>
+ * anchorOffset: 0
+ * focusNode: <TextNode>
+ * focusOffset: 3
+ *
+ * Firefox:
+ * anchorNode: <p>
+ * anchorOffset: 0
+ * focusNode: <p>
+ * focusOffset: 1
+ *
+ * So when getting the position for `focusNode`/`focusOffset`, we have to get
+ * the tail of section.
+ */
+test('#fromNode when offset refers to one past the number of child nodes of the node', function(assert) {
+  editor = Helpers.mobiledoc.renderInto(editorElement,
+    ({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let renderTree = editor._renderTree;
+  let elementNode = editorElement.firstChild;
+  let position = Position.fromNode(renderTree, elementNode, 1);
+
+  assert.positionIsEqual(position, editor.post.tailPosition());
+});
+
 test('#fromNode when node is card section element or next to it', (assert) => {
   let editorOptions = { cards: [{
     name: 'some-card',


### PR DESCRIPTION
Fixes #592 . Might also fix #543 (I'm not 100% sure, I haven't tried it).