### PR TITLE
[WIP] Link editing

### DIFF
--- a/assets/demo/demo.js
+++ b/assets/demo/demo.js
@@ -37,8 +37,12 @@ let activateButtons = (parentSelector, editor) => {
   $(`${parentSelector} button`).click(function() {
     let button = $(this);
     let action = button.data('action');
-    let arg = button.data('arg');
+    if (action === 'toggleLink') {
+      Mobiledoc.UI.toggleLink(editor);
+      return;
+    }
 
+    let arg = button.data('arg');
     editor[action](arg);
   });
 };

--- a/assets/demo/index.html
+++ b/assets/demo/index.html
@@ -60,8 +60,9 @@
           <button data-action='toggleSection' data-arg='h2'>Subheadline</button>
           <button data-action='toggleMarkup' data-arg='strong'>Bold</button>
           <button data-action='toggleMarkup' data-arg='em'>Italic</button>
-          <button data-action='toggleSection' data-arg='ul'>Bullet List</button>
-          <button data-action='toggleSection' data-arg='ol'>Number List</button>
+          <button data-action='toggleLink'>Link</button>
+          <button data-action='toggleSection' data-arg='ul'>Bulleted List</button>
+          <button data-action='toggleSection' data-arg='ol'>Numbered List</button>
         </div>
         <div id='editor'></div>
       </div>

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -268,7 +268,8 @@ class Editor {
   _addTooltip() {
     this.addView(new Tooltip({
       rootElement: this.element,
-      showForTag: 'a'
+      showForTag: 'a',
+      editor: this
     }));
   }
 
@@ -392,6 +393,11 @@ class Editor {
 
     this.cursor.selectRange(range);
     this.range = range;
+  }
+
+  selectNode(node) {
+    this.cursor.selectNode(node);
+    this.range = this.cursor.offsets;
   }
 
   get cursor() {

--- a/src/js/editor/ui.js
+++ b/src/js/editor/ui.js
@@ -48,13 +48,14 @@ export function toggleLink(editor, showPrompt=defaultShowPrompt) {
   }
 
   let selectedText = editor.cursor.selectedText();
+
+  let {range} = editor;
+  let link = editor.detectMarkupInRange(range, 'a');
+
   let defaultUrl = '';
   if (selectedText.indexOf('http') !== -1) { defaultUrl = selectedText; }
 
-  let {range} = editor;
-  let hasLink = editor.detectMarkupInRange(range, 'a');
-
-  if (hasLink) {
+  if (link) {
     editor.toggleMarkup('a');
   } else {
     showPrompt('Enter a URL', defaultUrl, url => {

--- a/src/js/utils/cursor.js
+++ b/src/js/utils/cursor.js
@@ -124,6 +124,10 @@ const Cursor = class Cursor {
     this.editor._ensureFocus();
   }
 
+  selectNode(node) {
+    this._moveToNode(node, 0, node, node.childNodes.length);
+  }
+
   get selection() {
     return window.getSelection();
   }

--- a/src/js/views/tooltip.js
+++ b/src/js/views/tooltip.js
@@ -1,4 +1,5 @@
 import View from './view';
+import { toggleLink } from '../editor/ui'
 import {
   positionElementCenteredBelow,
   getEventTargetMatchingTag,
@@ -6,10 +7,11 @@ import {
 } from '../utils/element-utils';
 
 const DELAY = 200;
+const EDIT_LINK_CLASSNAME = '__mobiledoc-tooltip__edit-link';
 
 export default class Tooltip extends View {
   constructor(options) {
-    let { rootElement } = options;
+    let { rootElement, editor } = options;
     let timeout;
     options.classNames = ['__mobiledoc-tooltip'];
     super(options);
@@ -31,6 +33,19 @@ export default class Tooltip extends View {
         this.hide();
       }
     });
+
+    this.addEventListener(this.element, 'click', (e) => {
+      let target = e.target;
+      if (target.classList.contains(EDIT_LINK_CLASSNAME)) {
+        e.preventDefault();
+        editor.selectNode(this.linkElement);
+        console.log(editor.range.head.offset, editor.range.tail.offset, '(', editor.cursor.offsets.head.offset, editor.cursor.offsets.tail.offset ,')')
+        editor.run(() => {})
+        console.log(editor.range.head.offset, editor.range.tail.offset, '(', editor.cursor.offsets.head.offset, editor.cursor.offsets.tail.offset ,')')
+        // editor.run(postEditor => postEditor.setRange(editor.range));
+        toggleLink(editor);
+      }
+    });
   }
 
   showMessage(message, element) {
@@ -40,8 +55,10 @@ export default class Tooltip extends View {
     positionElementCenteredBelow(tooltipElement, element);
   }
 
-  showLink(link, element) {
-    let message = `<a href="${link}" target="_blank">${link}</a>`;
+  showLink(url, element) {
+    this.linkUrl = url;
+    this.linkElement = element;
+    let message = `<a href="${url}" target="_blank" class="__mobiledoc-tooltip__link-url">${url}</a><button class="${EDIT_LINK_CLASSNAME}">Edit</button>`;
     this.showMessage(message, element);
     this.elementObserver = whenElementIsNotInDOM(element, () => this.hide());
   }


### PR DESCRIPTION
Currently, link editing is only possibly by selecting all of the linked text, clicking the link button to remove the markup, then clicking the link button to add a fresh link. It is easy to accidentally “split“ a link this way, and gets in the way of our common use case where we want the old link URL so, e.g. we can Google a new source for content that has 404’d or, more commonly, fix minor typos.

After exploring several UI and code paths, I think what is best is to have an “Edit” button in the link tooltip (that shows the URL on hover). This way, “Link” toolbar buttons implementing `toggleLink` would maintain their current behavior (toggle the link markup off), and the URL-editing button would explicitly appear alongside its URL.

**I’m currently stuck, though,** on getting the editor to recognize any programmatic selection—as far as I can tell, I am pushing the right data through the right internals—the DOM selection works,
and the `SelectionChangeObservers` fire, for instance—but haven’t been able to find the right combination of `setRange` & friends on `editor` or `postEditor` to get Mobiledoc to know the cursor is in the right spot…any ideas?
