### PR TITLE
Fix CI: Sauce Connect, ChromeHeadless, and MS Edge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ dist: trusty
 addons:
   chrome: stable
   sauce_connect:
-    username: mobiledoc-kit
-    access_key: f9cad21d-1141-452d-8f64-c6ba3f43faa6
+    username: "mobiledoc-kit"
+    access_key: "f9cad21d-1141-452d-8f64-c6ba3f43faa6"
 
 cache:
   yarn: true
@@ -18,6 +18,11 @@ cache:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.27.5
   - export PATH=$HOME/.yarn/bin:$PATH
+
+# Fixes issue starting ChromeHeadless, see https://github.com/travis-ci/travis-ci/issues/9024
+before_script:
+  - "sudo chown root /opt/google/chrome/chrome-sandbox"
+  - "sudo chmod 4755 /opt/google/chrome/chrome-sandbox"
 
 script:
   - yarn test:ci

--- a/testem-ci.json
+++ b/testem-ci.json
@@ -9,7 +9,7 @@
   "launchers": {
     "SL_MS_Edge": {
       "exe": "saucie",
-      "args": ["-b", "microsoftedge", "--no-connect", "-u"],
+      "args": ["-b", "microsoftedge", "-v", "15", "--no-connect", "-u"],
       "protocol": "tap"
     },
     "SL_IE_11": {


### PR DESCRIPTION
Adding quotes to the travis sauce connect addon username and access key
fixes issue connecting to Sauce Labs

Adding sudo chown/chmod calls fixes issue starting headless chrome,
see https://github.com/travis-ci/travis-ci/issues/9024

Forcing using MS Edge version 15 fixes 10 test failures that occur when
testing with MS Edge v16 (see #603)

Fixes #595