### PR TITLE
Revert "use travis sauce_connect addon"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,11 @@ dist: trusty
 addons:
   chrome: stable
   firefox: "latest"
-  sauce_connect:
-    username: "mobiledoc-kit"
-    access_key: "f9cad21d-1141-452d-8f64-c6ba3f43faa6"
 
 env:
   - MOZ_HEADLESS=1 # necessary for Firefox headless, see https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-the-Firefox-addon-in-headless-mode
+  - SAUCE_USERNAME=mobiledoc-kit
+  - SAUCE_ACCESS_KEY=f9cad21d-1141-452d-8f64-c6ba3f43faa6
 
 cache:
   yarn: true

--- a/sauce_labs/saucie-connect.js
+++ b/sauce_labs/saucie-connect.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+// From https://github.com/testem/testem/blob/master/examples/saucelabs/saucie-connect.js
+
+var saucie = require('saucie');
+var pidFile = 'sc_client.pid';
+
+var opts = {
+  username: process.env.SAUCE_USERNAME,
+  accessKey: process.env.SAUCE_ACCESS_KEY,
+  verbose: true,
+  logger: console.log,
+  pidfile: pidFile
+};
+
+if (process.env.TRAVIS_JOB_NUMBER) {
+  opts.tunnelIdentifier = process.env.TRAVIS_JOB_NUMBER;
+}
+
+saucie.connect(opts).then(function () {
+  process.exit();
+});

--- a/sauce_labs/saucie-disconnect.js
+++ b/sauce_labs/saucie-disconnect.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+// From https://github.com/testem/testem/blob/master/examples/saucelabs/saucie-disconnect.js
+
+var saucie = require('saucie');
+var pidFile = 'sc_client.pid';
+
+saucie.disconnect(pidFile);

--- a/testem-ci.js
+++ b/testem-ci.js
@@ -6,8 +6,15 @@ module.exports = {
   "timeout": 600,
   "browser_start_timeout": 90,
   "test_page": "dist/tests/index.html?hidepassed",
+  "on_start": "./sauce_labs/saucie-connect.js",
+  "on_exit": "./sauce_labs/saucie-disconnect.js",
   "port": 8080,
   "launchers": {
+    "SL_Chrome_Current": {
+      "exe": "saucie",
+      "args": ["-b", "chrome", "-p", "Windows 10", "-v", "latest", "--no-connect", "-u"],
+      "protocol": "tap"
+    },
     "SL_MS_Edge": {
       "exe": "saucie",
       "args": ["-b", "microsoftedge", "-v", "15", "--no-connect", "-u"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2586,8 +2586,8 @@ is-integer@^1.0.4:
     is-finite "^1.0.0"
 
 is-my-json-valid@^2.12.4:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz#5a846777e2c2620d1e69104e5d3a03b1f6088f11"
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz#f079dd9bfdae65ee2038aae8acbc86ab109e3693"
   dependencies:
     generate-function "^2.0.0"
     generate-object-property "^1.1.0"


### PR DESCRIPTION
This reverts commit e3e1d6bc25acf0df1f2a1cdd55befca7eb5e2875.

The travis sauce_connect addon is not available to pull requests from forks,
so it is a nonstarter for us.