### PR TITLE
Fix error when pasting HTML that parses to a blank doc

### DIFF
--- a/src/js/editor/post/post-inserter.js
+++ b/src/js/editor/post/post-inserter.js
@@ -278,7 +278,9 @@ export default class Inserter {
 
   insert(cursorPosition, newPost) {
     let visitor = new Visitor(this, cursorPosition);
-    visitor.visit(newPost);
+    if (!newPost.isBlank) {
+      visitor.visit(newPost);
+    }
     return visitor.cursorPosition;
   }
 }

--- a/tests/acceptance/editor-copy-paste-test.js
+++ b/tests/acceptance/editor-copy-paste-test.js
@@ -412,3 +412,25 @@ test('paste with shift key pastes plain text', (assert) => {
 
   assert.postIsSimilar(editor.post, expected);
 });
+
+test('paste with html that parses to blank doc doesn\'t error', (assert) => {
+  let expected;
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
+    expected = post([
+      markupSection('p', [])
+    ]);
+
+    return post([
+      markupSection('p', [marker('abcd')])
+    ]);
+  });
+
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  Helpers.dom.setCopyData('text/html', `<div></div>`);
+  editor.selectRange(editor.post.toRange());
+  Helpers.dom.triggerPasteEvent(editor);
+
+  assert.postIsSimilar(editor.post, expected);
+});


### PR DESCRIPTION
closes #619
- it's possible to paste HTML that parses into a blank doc, if the paste results in a section being replaced then the `post-inserter` would throw an error because it expects the new post to have sections
- adds a guard in the paste event handler to avoid inserting a blank post

QUESTIONS:
- [ ] do we want to keep the guard in the paste event or should the fix actually be in `post-inserter.js`?
- [ ] are we happy that a paste which results in a blank doc still performs the deletion and empty markup section creation? (I'm assuming a paste that parses to a blank doc was not intentional so may be confusing if the user only sees content being deleted)