### PR TITLE
Fix sticky modifier keys for word deletion

### DIFF
--- a/src/js/editor/event-manager.js
+++ b/src/js/editor/event-manager.js
@@ -21,9 +21,7 @@ export default class EventManager {
     this._textInputHandler = new TextInputHandler(editor);
     this._listeners = [];
     this.modifierKeys = {
-      shift: false,
-      alt:   false,
-      ctrl:  false
+      shift: false
     };
 
     this._selectionManager = new SelectionManager(
@@ -184,9 +182,9 @@ export default class EventManager {
       case key.isDelete(): {
         let { direction } = key;
         let unit = 'char';
-        if (this.modifierKeys.alt && Browser.isMac()) {
+        if (key.altKey && Browser.isMac()) {
           unit = 'word';
-        } else if (this.modifierKeys.ctrl && Browser.isWin()) {
+        } else if (key.ctrlKey && Browser.isWin()) {
           unit = 'word';
         }
         editor.performDelete({direction, unit});
@@ -284,10 +282,6 @@ export default class EventManager {
   _updateModifiersFromKey(key, {isDown}) {
     if (key.isShiftKey()) {
       this.modifierKeys.shift = isDown;
-    } else if (key.isAltKey()) {
-      this.modifierKeys.alt = isDown;
-    } else if (key.isCtrlKey()) {
-      this.modifierKeys.ctrl = isDown;
     }
   }
 

--- a/tests/acceptance/editor-sections-test.js
+++ b/tests/acceptance/editor-sections-test.js
@@ -5,6 +5,7 @@ import { NO_BREAK_SPACE } from 'mobiledoc-kit/renderers/editor-dom';
 import Range from 'mobiledoc-kit/utils/cursor/range';
 import Keycodes from 'mobiledoc-kit/utils/keycodes';
 import Browser from 'mobiledoc-kit/utils/browser';
+import { DIRECTION } from 'mobiledoc-kit/utils/key';
 
 const { test, module } = Helpers;
 
@@ -664,19 +665,23 @@ test('delete with option (Mac) or control (Win)  key deletes full word', (assert
 
   editor.selectRange(new Range(editor.post.tailPosition()));
 
-  let keyCode = Browser.isMac() ? Keycodes.ALT : Keycodes.CTRL;
+  let altKey, ctrlKey;
+  if (Browser.isMac()) {
+    /* Mac key codes for navigation by word */
+    altKey = true;
+    ctrlKey = false;
+  } else {
+    /* PC key codes for navigation by word */
+    altKey = false;
+    ctrlKey = true;
+  }
 
-  Helpers.dom.triggerKeyEvent(editor, 'keydown', {keyCode});
   Helpers.wait(() => {
-    Helpers.dom.triggerDelete(editor);
+    Helpers.dom.triggerDelete(editor, DIRECTION.BACKWARD, {altKey, ctrlKey});
 
     Helpers.wait(() => {
-      Helpers.dom.triggerKeyEvent(editor, 'keyup', {keyCode});
-
-      Helpers.wait(() => {
-        assert.postIsSimilar(editor.post, expected);
-        done();
-      });
+      assert.postIsSimilar(editor.post, expected);
+      done();
     });
   });
 });

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -154,18 +154,20 @@ function createMockEvent(eventName, element, options={}) {
   return event;
 }
 
-function triggerDelete(editor, direction=DIRECTION.BACKWARD) {
+// options is merged into the mocked `KeyboardEvent` data.
+// Useful for simulating modifier keys, eg:
+// triggerDelete(editor, DIRECTION.BACKWARD, {altKey: true})
+function triggerDelete(editor, direction=DIRECTION.BACKWARD, options={}) {
   assertEditor(editor);
   const keyCode = direction === DIRECTION.BACKWARD ? KEY_CODES.BACKSPACE :
                                                      KEY_CODES.DELETE;
-  let event = createMockEvent('keydown', editor.element, {
-    keyCode
-  });
+  let eventOptions = merge({keyCode}, options);
+  let event = createMockEvent('keydown', editor.element, eventOptions);
   _triggerEditorEvent(editor, event);
 }
 
-function triggerForwardDelete(editor) {
-  return triggerDelete(editor, DIRECTION.FORWARD);
+function triggerForwardDelete(editor, options) {
+  return triggerDelete(editor, DIRECTION.FORWARD, options);
 }
 
 function triggerEnter(editor) {


### PR DESCRIPTION
closes https://github.com/bustle/mobiledoc-kit/issues/625
- use `key.altKey/shiftKey` getters when instigating word deletion in `event-manager.js`
    - word deletion is only triggered on <kbd>Backspace</kbd> and <kbd>Delete</kbd> so we can use the the browser-provided modifiers on the KeyboardEvent instead the internal modifier key tracking which is not reliable when the editor loses focus
- update `triggerDelete` and `triggerForwardDelete` test helpers to accept an `options` argument so that modifier keys can be passed in as event arguments