### PR TITLE
Run parser plugins for top-level unknown elements

### DIFF
--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -69,7 +69,13 @@ class SectionParser {
 
     this._updateStateFromElement(element);
 
-    let finished = this.runPlugins(element);
+    let finished = false;
+
+    // top-level text nodes will be run through parseNode later so avoid running
+    // the node through parserPlugins twice
+    if (!isTextNode(element)) {
+      finished = this.runPlugins(element);
+    }
 
     if (!finished) {
       let childNodes = isTextNode(element) ? [element] : element.childNodes;

--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -69,14 +69,18 @@ class SectionParser {
 
     this._updateStateFromElement(element);
 
-    let childNodes = isTextNode(element) ? [element] : element.childNodes;
+    let finished = this.runPlugins(element);
 
-    if (this.state.section.isListSection) {
-      this.parseListItems(childNodes);
-    } else {
-      forEach(childNodes, el => {
-        this.parseNode(el);
-      });
+    if (!finished) {
+      let childNodes = isTextNode(element) ? [element] : element.childNodes;
+
+      if (this.state.section.isListSection) {
+        this.parseListItems(childNodes);
+      } else {
+        forEach(childNodes, el => {
+          this.parseNode(el);
+        });
+      }
     }
 
     this._closeCurrentSection();

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -354,7 +354,7 @@ test('editor parses HTML post using parser plugins', (assert) => {
   editor = new Editor({html, parserPlugins: [parserPlugin]});
   assert.ok(!!editor.post, 'editor loads post');
 
-  assert.deepEqual(seenTagNames, ['TEXTAREA', 'IMG']);
+  assert.deepEqual(seenTagNames, ['P', 'TEXTAREA', 'IMG']);
 });
 
 test('#activeMarkups returns the markups at cursor when range is collapsed', (assert) => {

--- a/tests/unit/parsers/html-test.js
+++ b/tests/unit/parsers/html-test.js
@@ -47,25 +47,37 @@ test('newlines ("\\n") are replaced with space characters', (assert) => {
 // see https://github.com/bustlelabs/mobiledoc-kit/issues/494
 test('top-level unknown void elements are parsed', (assert) => {
   let html = `<video />`;
-  parseHTML(html, {plugins: [videoParserPlugin]});
+  let post = parseHTML(html, {plugins: [videoParserPlugin]});
+  let {post: expected} = Helpers.postAbstract.buildFromText([]);
+
   assert.ok(didParseVideo);
+  assert.postIsSimilar(post, expected);
 });
 
 // see https://github.com/bustlelabs/mobiledoc-kit/issues/494
 test('top-level unknown elements are parsed', (assert) => {
   let html = `<video>...inner...</video>`;
-  parseHTML(html, {plugins: [videoParserPlugin]});
+  let post = parseHTML(html, {plugins: [videoParserPlugin]});
+  let {post: expected} = Helpers.postAbstract.buildFromText(['...inner...']);
+
   assert.ok(didParseVideo);
+  assert.postIsSimilar(post, expected);
 });
 
 test('nested void unknown elements are parsed', (assert) => {
   let html = `<p>...<video />...</p>`;
-  parseHTML(html, {plugins: [videoParserPlugin]});
+  let post = parseHTML(html, {plugins: [videoParserPlugin]});
+  let {post: expected} = Helpers.postAbstract.buildFromText(['......']);
+
   assert.ok(didParseVideo);
+  assert.postIsSimilar(post, expected);
 });
 
 test('nested unknown elements are parsed', (assert) => {
   let html = `<p>...<video>inner</video>...</p>`;
-  parseHTML(html, {plugins: [videoParserPlugin]});
+  let post = parseHTML(html, {plugins: [videoParserPlugin]});
+  let {post: expected} = Helpers.postAbstract.buildFromText(['...inner...']);
+
   assert.ok(didParseVideo);
+  assert.postIsSimilar(post, expected);
 });


### PR DESCRIPTION
closes #494
- run parser plugins for the top-level section elements
    - do not continue parsing children elements if a parser marks the top-level element as finished
- update tests to double-check the output for top-level elements is unchanged

@bantic I'd be interested in a quick review and any pointers for any edge cases/tests you think may need adding 😄