### PR TITLE
Fixed Ctrl+Backspace word delete on Linux

### DIFF
--- a/src/js/editor/event-manager.js
+++ b/src/js/editor/event-manager.js
@@ -184,7 +184,7 @@ export default class EventManager {
         let unit = 'char';
         if (key.altKey && Browser.isMac()) {
           unit = 'word';
-        } else if (key.ctrlKey && Browser.isWin()) {
+        } else if (key.ctrlKey && !Browser.isMac()) {
           unit = 'word';
         }
         editor.performDelete({direction, unit});


### PR DESCRIPTION
closes #634
- toggle <kbd>Ctrl+Backspace</kbd> behaviour based on not being on Mac rather than checking for Windows explicitly