### PR TITLE
[SPIKE] Add delete to start of line for MacOS

### DIFF
--- a/src/js/editor/event-manager.js
+++ b/src/js/editor/event-manager.js
@@ -184,6 +184,8 @@ export default class EventManager {
         let unit = 'char';
         if (key.altKey && Browser.isMac()) {
           unit = 'word';
+        } else if (key.metaKey && Browser.isMac()) {
+          unit = 'line';
         } else if (key.ctrlKey && Browser.isWin()) {
           unit = 'word';
         }

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -401,7 +401,16 @@ class PostEditor {
       this.toggleSection('p', position);
       return this._range.head;
     } else {
-      let prevPosition = unit === 'word' ? position.moveWord(BACKWARD) : position.move(BACKWARD);
+      let prevPosition;
+
+      if (unit === 'word') {
+        prevPosition = position.moveWord(BACKWARD);
+      } else if (unit === 'line') {
+        prevPosition = Position.atStartOfLine(position, this.editor);
+      } else {
+        prevPosition = position.move(BACKWARD);
+      }
+
       let range = prevPosition.toRange(position);
       return this.deleteRange(range);
     }


### PR DESCRIPTION
refs https://github.com/bustle/mobiledoc-kit/issues/445
- add `Position.atStartOfLine` method that takes an existing position from which to find the start of it's line
- add `line` unit for use in `editor.performDelete`
- update delete key event handler to pass `line` unit when <kbd>Meta+Backspace</kbd> is pressed

I had a quick stab at re-implementing the default MacOS <kbd>Cmd+Backspace</kbd> behaviour but it's highlighted a problem. macOS allows you to place the caret visually at the end of the line when it's actual position is at the start of the next line (either through clicking at the end of the line or using <kbd>Cmd+Right</kbd>). You can see a demonstration here:

![delete-line-buggy](https://user-images.githubusercontent.com/415/43460891-e4149c68-94c9-11e8-95c4-c064f9f405f1.gif)

When using both mobiledoc-kit's internal `position` and the browser-provided `document.getSelection().getRangeAt(0).getBoundingClientRect()` the only position exposed to JS is the beginning of the next line. The reason this is a problem is because to faithfully replicate macOS' default behaviour the delete needs to happen from the visual caret position rather than the logical caret position.

I disabled the delete key event handling in `event-manager.js` to demonstrate the native macOS behaviour where you can see the delete happening from the visual rather than logical position:

![delete-line-native](https://user-images.githubusercontent.com/415/43461011-401145b6-94ca-11e8-99ea-bdf9e62a100f.gif)