### PR TITLE
Fixed copy/paste of card section following a list section

### DIFF
--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -222,6 +222,7 @@ class Post {
         );
       } else {
         newSection = section.clone();
+        sectionParent = post;
       }
       if (sectionParent) {
         sectionParent.sections.append(newSection);


### PR DESCRIPTION
closes https://github.com/bustle/mobiledoc-kit/issues/637
- if a non-markerable section immediately followed a list section the `post.trimTo()` was not appending it to the post
- resetting the `sectionParent` to the `post` object when hitting a non-markerable section allows all sections to be appended to the constrained post