### PR TITLE
[SPIKE] Fix typing on Android

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -462,7 +462,7 @@ class Editor {
     });
     this.rerender();
     if (currentRange) {
-      this.selectRange(currentRange);
+      this.selectRange(currentRange.move(DIRECTION.FORWARD));
     }
 
     this.runCallbacks(CALLBACK_QUEUES.DID_REPARSE);

--- a/tests/acceptance/editor-reparse-test.js
+++ b/tests/acceptance/editor-reparse-test.js
@@ -239,6 +239,29 @@ test('inserting text into text node on left/right of atom is reparsed correctly'
   });
 });
 
+test('inserting a single character into an empty section moves the cursor forward', (assert) => {
+  let done = assert.async();
+  let expected;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+    expected = post([
+      markupSection('p', [marker('Z')]),
+    ]);
+
+    return post([markupSection('p', [])]);
+  }, editorOptions);
+
+  let node = editorElement.firstChild.firstChild;
+  node.textContent = 'Z';
+
+  Helpers.wait(() => {
+    assert.postIsSimilar(editor.post, expected);
+    assert.equal(editor.range.head.offset, 1);
+    assert.equal(editor.range.tail.offset, 1);
+
+    done();
+  });
+});
+
 test('mutation inside card element does not cause reparse', (assert) => {
   let done = assert.async();
   let parseCount = 0;


### PR DESCRIPTION
This is not a proper fix for https://github.com/bustle/mobiledoc-kit/issues/445, but rather a hacky workaround for anyone that really needs some kind of Android support. It does however work on my Pixel and in the emulator without breaking existing use cases. I'll keep this branch alive until a better fix is implemented.

[Screen recording of this branch on an actual device](https://www.dropbox.com/s/xtugf75xbq01oj7/mobiledoc.mp4?dl=0)

After spending a bit of time reading code I'm still not familiar enough with Mobiledoc internals to attempt a proper fix.. @mixonic I wonder if your attempts to operate without keypress ([1](https://github.com/bustle/mobiledoc-kit/issues/445#issuecomment-403903643), [2](https://github.com/bustle/mobiledoc-kit/issues/589#issuecomment-399323579)) were sucessfull? That approach could probably fix https://github.com/bustle/mobiledoc-kit/issues/621 as well by eliminating renderers?