### PR TITLE
fixes #642

### DIFF
--- a/src/js/editor/event-manager.js
+++ b/src/js/editor/event-manager.js
@@ -192,6 +192,7 @@ export default class EventManager {
         break;
       }
       case key.isEnter():
+        this._textInputHandler.handleNewLine();
         editor.handleNewline(event);
         break;
       case key.isTab():

--- a/src/js/editor/text-input-handler.js
+++ b/src/js/editor/text-input-handler.js
@@ -1,6 +1,7 @@
 import { endsWith } from 'mobiledoc-kit/utils/string-utils';
 import assert from 'mobiledoc-kit/utils/assert';
 import deprecate from 'mobiledoc-kit/utils/deprecate';
+import { ENTER } from 'mobiledoc-kit/utils/characters';
 
 class TextInputHandler {
   constructor(editor) {
@@ -24,6 +25,7 @@ class TextInputHandler {
 
   handle(string) {
     let { editor } = this;
+
     editor.insertText(string);
 
     let matchedHandler = this._findHandler();
@@ -33,9 +35,19 @@ class TextInputHandler {
     }
   }
 
-  _findHandler() {
+  handleNewLine() {
+    let { editor } = this;
+
+    let matchedHandler = this._findHandler(ENTER);
+    if (matchedHandler) {
+      let [ handler, matches ] = matchedHandler;
+      handler.run(editor, matches);
+    }
+  }
+
+  _findHandler(string = "") {
     let { editor: { range: { head, head: { section } } } } = this;
-    let preText = section.textUntil(head);
+    let preText = section.textUntil(head) + string;
 
     for (let i=0; i < this._handlers.length; i++) {
       let handler = this._handlers[i];

--- a/tests/acceptance/editor-input-handlers-test.js
+++ b/tests/acceptance/editor-input-handlers-test.js
@@ -1,7 +1,7 @@
 import Helpers from '../test-helpers';
 import Range from 'mobiledoc-kit/utils/cursor/range';
 import { NO_BREAK_SPACE } from 'mobiledoc-kit/renderers/editor-dom';
-import { TAB } from 'mobiledoc-kit/utils/characters';
+import { TAB, ENTER } from 'mobiledoc-kit/utils/characters';
 import { MODIFIERS }  from 'mobiledoc-kit/utils/key';
 
 const { module, test } = Helpers;
@@ -297,6 +297,23 @@ test('input handler can be triggered by TAB', (assert) => {
   });
 
   Helpers.dom.insertText(editor, TAB);
+
+  assert.ok(didMatch);
+});
+
+test('input handler can be triggered by ENTER', (assert) => {
+  editor = Helpers.editor.buildFromText('abc|', {element: editorElement});
+
+  let didMatch;
+  editor.onTextInput({
+    name: 'test',
+    match: /abc\n/,
+    run() {
+      didMatch = true;
+    }
+  });
+
+  Helpers.dom.insertText(editor, ENTER);
 
   assert.ok(didMatch);
 });


### PR DESCRIPTION
Failing test for #642.

Adding `this._textInputHandler.handle(key.toString());` on the event manager like we did for tabs doesn't work. Brings up a lot of new errors.