### PR TITLE
Fix json format issue in card description

### DIFF
--- a/MOBILEDOC.md
+++ b/MOBILEDOC.md
@@ -98,7 +98,7 @@ Cards have a name and arbitrary payload.
   cards: [
     [cardName, cardPayload],            ──── Card
     ['image', {                         ──── Example 'image' card
-      src: 'http://google.com/logo.png'
+      'src': 'http://google.com/logo.png'
     }]
   ]
 }


### PR DESCRIPTION
This pull request fixes my issue in #644 by adding the JSON-format required quotation marks around the `src` key in the cards example in [MOBILEDOC.md](https://github.com/bustle/mobiledoc-kit/blob/master/MOBILEDOC.md)