### PR TITLE
walk sections instead of iterating

### DIFF
--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -25,7 +25,11 @@ import { ZWNJ } from 'mobiledoc-kit/renderers/editor-dom';
 
 import SectionParser from 'mobiledoc-kit/parsers/section';
 import Markup from 'mobiledoc-kit/models/markup';
+import { VALID_LIST_SECTION_TAGNAMES } from 'mobiledoc-kit/models/list-section';
 import { VALID_MARKUP_SECTION_TAGNAMES } from 'mobiledoc-kit/models/markup-section';
+import { VALID_MARKUP_TAGNAMES } from 'mobiledoc-kit/models/markup';
+
+const VALID_TAGNAMES = [].concat(VALID_LIST_SECTION_TAGNAMES, VALID_MARKUP_SECTION_TAGNAMES, VALID_MARKUP_TAGNAMES);
 
 const GOOGLE_DOCS_CONTAINER_ID_REGEX = /^docs\-internal\-guid/;
 
@@ -47,7 +51,7 @@ function isGoogleDocsContainer(element) {
 
 function isValidSection(element) {
   return isElementNode(element) &&
-    contains(VALID_MARKUP_SECTION_TAGNAMES, normalizeTagName(element.tagName));
+    contains(VALID_TAGNAMES, normalizeTagName(element.tagName));
 }
 
 function detectRootElement(element) {

--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -50,7 +50,9 @@ function isGoogleDocsContainer(element) {
 
 function isValidSection(element) {
   return isElementNode(element) &&
-    contains(VALID_TAGNAMES, normalizeTagName(element.tagName));
+    contains(VALID_TAGNAMES, normalizeTagName(element.tagName)) &&
+    // We should never treat a Google Docs container as a section
+    !isGoogleDocsContainer(element);
 }
 
 function detectRootElement(element) {

--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -27,9 +27,8 @@ import SectionParser from 'mobiledoc-kit/parsers/section';
 import Markup from 'mobiledoc-kit/models/markup';
 import { VALID_LIST_SECTION_TAGNAMES } from 'mobiledoc-kit/models/list-section';
 import { VALID_MARKUP_SECTION_TAGNAMES } from 'mobiledoc-kit/models/markup-section';
-import { VALID_MARKUP_TAGNAMES } from 'mobiledoc-kit/models/markup';
 
-const VALID_TAGNAMES = [].concat(VALID_LIST_SECTION_TAGNAMES, VALID_MARKUP_SECTION_TAGNAMES, VALID_MARKUP_TAGNAMES);
+const VALID_TAGNAMES = [].concat(VALID_LIST_SECTION_TAGNAMES, VALID_MARKUP_SECTION_TAGNAMES);
 
 const GOOGLE_DOCS_CONTAINER_ID_REGEX = /^docs\-internal\-guid/;
 

--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -45,6 +45,11 @@ function isGoogleDocsContainer(element) {
          GOOGLE_DOCS_CONTAINER_ID_REGEX.test(element.id);
 }
 
+function isValidSection(element) {
+  return isElementNode(element) &&
+    contains(VALID_MARKUP_SECTION_TAGNAMES, normalizeTagName(element.tagName));
+}
+
 function detectRootElement(element) {
   let childNodes = element.childNodes || [];
   let googleDocsContainer = detect(childNodes, isGoogleDocsContainer);
@@ -97,10 +102,10 @@ function walkSectionNodes(parent, callback) {
   // If we found a text node, we went too far
   if (isTextNode(currentNode)) {
     callback(currentNode.parentNode);
-  } else if (isElementNode(currentNode) &&
-    contains(VALID_MARKUP_SECTION_TAGNAMES, currentNode.tagName)
-  ) {
+  // If we find a valid section, callback
+  } else if (isValidSection(currentNode)) {
     callback(currentNode);
+  // Otherwise, look at the next available node
   } else {
     currentNode = currentNode.firstChild;
     while (currentNode) {

--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -103,9 +103,14 @@ function walkMarkerableNodes(parent, callback) {
 function walkSectionNodes(parent, callback) {
   var currentNode = parent;
 
-  // If we found a text node, we went too far
   if (isTextNode(currentNode)) {
+    // If we found a text node with no siblings, we probably went too far
+    if (currentNode.parentNode.childNodes.length === 1) {
     callback(currentNode.parentNode);
+    } else {
+      callback(currentNode);
+    }
+
   // If we find a valid section, callback
   } else if (isValidSection(currentNode)) {
     callback(currentNode);

--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -116,6 +116,9 @@ function walkSectionNodes(parent, callback) {
     callback(currentNode);
   // Otherwise, look at the next available node
   } else {
+    if (!currentNode.firstChild) {
+      callback(currentNode);
+    }
     currentNode = currentNode.firstChild;
     while (currentNode) {
       walkSectionNodes(currentNode, callback);

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -69,7 +69,10 @@ let expectations = [
   ['abc\ndef', ['abc def']],
 
   // See https://github.com/bustle/mobiledoc-kit/issues/648
-  ['<div><p>first</p><p>second</p></div>', ['first', 'second']]
+  ['<div><p>first</p><p>second</p></div>', ['first', 'second']],
+  ['<div><div><p>first</p><p>second</p></div></div>', ['first', 'second']],
+  ['<div><div><p>first</p></div><p>second</p></div>', ['first', 'second']],
+  ['<div><p>first</p><div><p>second</p></div></div>', ['first', 'second']]
 ];
 
 expectations.forEach(([html, dslText]) => {

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -66,7 +66,10 @@ let expectations = [
   ['<ul><li>first element</li><li><ul><li>nested element</li></ul></li></ul>', ['* first element', '* nested element']],
 
   // See https://github.com/bustle/mobiledoc-kit/issues/333
-  ['abc\ndef', ['abc def']]
+  ['abc\ndef', ['abc def']],
+
+  // See https://github.com/bustle/mobiledoc-kit/issues/648
+  ['<div><p>first</p><p>second</p></div>', ['first', 'second']]
 ];
 
 expectations.forEach(([html, dslText]) => {


### PR DESCRIPTION
closes https://github.com/bustle/mobiledoc-kit/issues/648

I haven't figured out how to write tests for mobiledoc-kit yet. I've done rudimentary testing by writing a test for the 4 cases I outlined in #648 in the html-to-mobiledoc kit lib [here](https://github.com/TryGhost/Ghost-SDK/blob/master/packages/html-to-mobiledoc/test/converter.test.js#L44).

I need to do much more extensive testing around text nodes, and what happens if the DOM is empty, etc etc, but I _think_ this approach is sound.

Will look into writing native tests and wider examples asap.

- Use a dom walker
- Look for valid sections or text nodes
- Parse the sections that are found