### PR TITLE
648 Fix proposal 2: Handle wrappers, siblings and some trees

### DIFF
--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -16,6 +16,7 @@ import {
   normalizeTagName
 } from '../utils/dom-utils';
 import {
+  contains,
   detect,
   forEach
 } from '../utils/array-utils';
@@ -43,15 +44,34 @@ function isGoogleDocsContainer(element) {
          GOOGLE_DOCS_CONTAINER_ID_REGEX.test(element.id);
 }
 
+function isWrapperElement(element) {
+  return !isTextNode(element) &&
+    !isCommentNode(element) &&
+    contains([normalizeTagName('div'), normalizeTagName('section')], normalizeTagName(element.tagName));
+}
+
+function skipRootWrapperElements(element) {
+  let childNodes = element.childNodes || [];
+
+  if (
+    childNodes.length === 1 &&
+    isWrapperElement(element.firstChild)
+  ) {
+    return skipRootWrapperElements(element.firstChild);
+  }
+
+  return element;
+}
+
 function detectRootElement(element) {
   let childNodes = element.childNodes || [];
   let googleDocsContainer = detect(childNodes, isGoogleDocsContainer);
 
   if (googleDocsContainer) {
     return googleDocsContainer;
-  } else {
-    return element;
   }
+
+  return skipRootWrapperElements(element);
 }
 
 const TAG_REMAPPING = {

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -75,7 +75,15 @@ let structures = [
   ['<section><div><p>first</p><p>second</p></div></section>', ['first', 'second'], 'two levels'],
   ['<section><div><div><p>first</p><p>second</p></div></div></section>', ['first', 'second'], 'three levels'],
   ['<section><div><p>first</p></div><p>second</p></section>', ['first', 'second'], 'offset left'],
-  ['<section><p>first</p><div><p>second</p></div></section>', ['first', 'second'], 'offset right']
+  ['<section><p>first</p><div><p>second</p></div></section>', ['first', 'second'], 'offset right'],
+  // Part two - siblings
+  ['<section><p>first</p></section><section><p>second</p></section>', ['first', 'second'], 'siblings'],
+  ['<div><section><p>first</p></section><section><p>second</p></section></div>', ['first', 'second'], 'wrapped siblings' ],
+  ['<section><div><p>first</p></div></section><section><div><p>second</p></div></section>', ['first', 'second'], 'two-level siblings'],
+  ['<section><div><p>first</p></div></section><section><p>second</p></section>', ['first', 'second'], 'offset siblings left'],
+  ['<section><p>first</p></section><section><div><p>second</p></div></section>', ['first', 'second'], 'offset siblings right'],
+  // Part three - trees
+  ['<section><p>first</p></section><section><div><p>second</p></div><section><div><p>third</p><p>fourth</p></div></section></section>', ['first', 'second', 'third', 'fourth'], 'tree']
 ];
 
 expectations.forEach(([html, dslText]) => {

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -69,7 +69,10 @@ let expectations = [
   ['abc\ndef', ['abc def']],
 
   // See https://github.com/bustle/mobiledoc-kit/issues/648
-  ['<div><p>first</p><p>second</p></div>', ['first', 'second']]
+  ['<div><p>first</p><p>second</p></div>', ['first', 'second']],
+  ['<div><div><p>first</p><p>second</p></div></div>', ['first', 'second']],
+  ['<div><div><p>first</p></div><p>second</p></div>', ['first', 'second']],
+  ['<div><p>first</p><div><p>second</p></div></div>', ['first', 'second']]
 ];
 
 expectations.forEach(([html, dslText]) => {

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -66,7 +66,10 @@ let expectations = [
   ['<ul><li>first element</li><li><ul><li>nested element</li></ul></li></ul>', ['* first element', '* nested element']],
 
   // See https://github.com/bustle/mobiledoc-kit/issues/333
-  ['abc\ndef', ['abc def']]
+  ['abc\ndef', ['abc def']],
+
+  // See https://github.com/bustle/mobiledoc-kit/issues/648
+  ['<div><p>first</p><p>second</p></div>', ['first', 'second']]
 ];
 
 expectations.forEach(([html, dslText]) => {


### PR DESCRIPTION
This PR is a proposal to fix _most_ of #648, where wrapping, sibling and nested divs cause paragraphs and other "section" elements to be incorrectly merged.

----

The first 4 commits are the same as Proposal 1.

The penultimate commit adds further tests showing additional cases which can be solved with the additional changes.

The last commit moves the recursive search to be performed for each sibling, extending down each branch of the tree until a root / non-wrapper element is found for each branch.



