### PR TITLE
648 Fix proposal 1: Remove wrappers

### DIFF
--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -16,6 +16,7 @@ import {
   normalizeTagName
 } from '../utils/dom-utils';
 import {
+  contains,
   detect,
   forEach
 } from '../utils/array-utils';
@@ -43,15 +44,34 @@ function isGoogleDocsContainer(element) {
          GOOGLE_DOCS_CONTAINER_ID_REGEX.test(element.id);
 }
 
+function isWrapperElement(element) {
+  return !isTextNode(element) &&
+    !isCommentNode(element) &&
+    contains([normalizeTagName('div'), normalizeTagName('section')], normalizeTagName(element.tagName));
+}
+
+function skipRootWrapperElements(element) {
+  let childNodes = element.childNodes || [];
+
+  if (
+    childNodes.length === 1 &&
+    isWrapperElement(element.firstChild)
+  ) {
+    return skipRootWrapperElements(element.firstChild);
+  }
+
+  return element;
+}
+
 function detectRootElement(element) {
   let childNodes = element.childNodes || [];
   let googleDocsContainer = detect(childNodes, isGoogleDocsContainer);
 
   if (googleDocsContainer) {
     return googleDocsContainer;
-  } else {
-    return element;
   }
+
+  return skipRootWrapperElements(element);
 }
 
 const TAG_REMAPPING = {

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -69,7 +69,10 @@ let expectations = [
   ['abc\ndef', ['abc def']],
 
   // See https://github.com/bustle/mobiledoc-kit/issues/648
-  ['<div><p>first</p><p>second</p></div>', ['first', 'second']]
+  ['<div><p>first</p><p>second</p></div>', ['first', 'second']],
+  ['<div><div><p>first</p><p>second</p></div></div>', ['first', 'second']],
+  ['<div><div><p>first</p></div><p>second</p></div>', ['first', 'second']],
+  ['<div><p>first</p><div><p>second</p></div></div>', ['first', 'second']]
 ];
 
 expectations.forEach(([html, dslText]) => {

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -66,7 +66,10 @@ let expectations = [
   ['<ul><li>first element</li><li><ul><li>nested element</li></ul></li></ul>', ['* first element', '* nested element']],
 
   // See https://github.com/bustle/mobiledoc-kit/issues/333
-  ['abc\ndef', ['abc def']]
+  ['abc\ndef', ['abc def']],
+
+  // See https://github.com/bustle/mobiledoc-kit/issues/648
+  ['<div><p>first</p><p>second</p></div>', ['first', 'second']]
 ];
 
 expectations.forEach(([html, dslText]) => {


### PR DESCRIPTION
This PR is a proposal to fix _part_ of #648, where wrapping divs cause paragraphs and other "section" elements to be incorrectly merged.

It is **not** the preferred fix. The preferred fix is Proposal 2 😁 

----

The first 3 commits are tests only.

The final commit adds a recursive search for the root element. It attempts to find the innermost wrapper <div> or <section> and use this as the root element. The children of this innermost wrapper are then iterated over as sections, the same as before.



