### PR TITLE
Handle nested section-creating elements in SectionParser

### DIFF
--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -150,6 +150,18 @@ class SectionParser {
       let isNestedListSection = isListSection && this.state.section.isListItem;
       let lastSection = this.sections[this.sections.length - 1];
 
+      // we can hit a list item after parsing a nested list, when that happens
+      // and the lists are of different types we need to make sure we switch
+      // the list type back
+      if (isListItem && lastSection && lastSection.isListSection) {
+        let parentElement = node.parentElement;
+        let parentElementTagName = normalizeTagName(parentElement.tagName);
+        if (parentElementTagName !== lastSection.tagName) {
+          this._closeCurrentSection();
+          this._updateStateFromElement(parentElement);
+        }
+      }
+
       // if we've broken out of a list due to nested section-level elements we
       // can hit the next list item without having a list section in the current
       // state. In this instance we find the parent list node and use it to
@@ -159,9 +171,8 @@ class SectionParser {
         !(this.state.section.isListItem || this.state.section.isListSection) &&
         !lastSection.isListSection
       ) {
-        let closestListNode = node.closest(VALID_LIST_SECTION_TAGNAMES.join(','));
         this._closeCurrentSection();
-        this._updateStateFromElement(closestListNode);
+        this._updateStateFromElement(node.parentElement);
       }
 
       // if we have consecutive list sections of different types (ul, ol) then

--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -129,6 +129,7 @@ class SectionParser {
     return false;
   }
 
+  /* eslint-disable complexity */
   parseNode(node) {
     if (!this.state.section) {
       this._updateStateFromElement(node);
@@ -143,12 +144,24 @@ class SectionParser {
     // new-section-creating element.
     if (this.state.section && !isTextNode(node) && node.tagName) {
       let tagName = normalizeTagName(node.tagName);
-      let isNestedListSection = contains(VALID_LIST_SECTION_TAGNAMES, tagName)
+
+      let isListSection = contains(VALID_LIST_SECTION_TAGNAMES, tagName);
+      let isNestedListSection = isListSection
         && this.state.section.isListItem;
 
+      // if we have consecutive list sections of different types (ul, ol) then
+      // ensure we close the current section and start a new one
+      let lastSection = this.sections[this.sections.length - 1];
+      let isNewListSection = lastSection
+        && lastSection.isListSection
+        && this.state.section.isListItem
+        && isListSection
+        && tagName !== lastSection.tagName;
+
       if (
+        isNewListSection ||
+        (isListSection && !isNestedListSection) ||
         contains(VALID_MARKUP_SECTION_TAGNAMES, tagName) ||
-        (contains(VALID_LIST_SECTION_TAGNAMES, tagName) && !isNestedListSection) ||
         contains(VALID_LIST_ITEM_TAGNAMES, tagName)
       ) {
         // don't break out of the list for list items that contain a single <p>.

--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -109,7 +109,13 @@ class SectionParser {
     let isNodeFinished = false;
     let env = {
       addSection: (section) => {
-        this._closeCurrentSection();
+        // avoid creating empty paragraphs due to wrapper elements around
+        // parser-plugin-handled elements
+        if (this.state.section.isMarkerable && !this.state.text) {
+          this.state.section = null;
+        } else {
+          this._closeCurrentSection();
+        }
         this.sections.push(section);
       },
       addMarkerable: (marker) => {
@@ -146,6 +152,33 @@ class SectionParser {
     let nodeFinished = this.runPlugins(node);
     if (nodeFinished) {
       return;
+    }
+
+    // handle closing the current section and starting a new one if we hit a
+    // new-section-creating element
+    if (this.state.section && !this.state.section.isListItem && !isTextNode(node) && node.tagName) {
+      // handle lists nested inside wrappers
+      if (this.state.section.isListSection) {
+        this.parseListItems(node.childNodes);
+        return;
+      }
+
+      let tagName = normalizeTagName(node.tagName);
+      if (contains(VALID_MARKUP_SECTION_TAGNAMES, tagName) || contains(VALID_LIST_SECTION_TAGNAMES, tagName)) {
+        // avoid creating empty paragraphs due to wrappers elements around
+        // section-creating elements
+        if (this.state.section.isMarkerable && !this.state.text) {
+          this.state.section = null;
+        } else {
+          this._closeCurrentSection();
+        }
+        this._updateStateFromElement(node);
+
+        if (this.state.section.isListSection) {
+          this.parseListItems(node.childNodes);
+          return;
+        }
+      }
     }
 
     switch (node.nodeType) {

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -49,6 +49,7 @@ let expectations = [
   ['<p>first line</p>\n<p>second line</p>', ['first line','second line']],
   ['<p>first line</p>middle line<p>third line</p>', ['first line','middle line','third line']],
   ['<p>first line</p>second line', ['first line','second line']],
+  ['<p>first line</p><p></p><p>third line</p>', ['first line', 'third line']],
 
   ['<b>bold text</b>',['*bold text*']],
 

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -69,7 +69,10 @@ let expectations = [
   ['abc\ndef', ['abc def']],
 
   // See https://github.com/bustle/mobiledoc-kit/issues/648
-  ['<div><p>first</p><p>second</p></div>', ['first', 'second']]
+  ['<div><p>first</p><p>second</p></div>', ['first', 'second']],
+  ['<div><div><p>first</p><p>second</p></div></div>', ['first', 'second']],
+  ['<div><div><p>first</p></div><p>second</p></div>', ['first', 'second']],
+  ['<div><p>first</p><div><p>second</p></div></div>', ['first', 'second']]
 ];
 
 expectations.forEach(([html, dslText]) => {

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -66,7 +66,10 @@ let expectations = [
   ['<ul><li>first element</li><li><ul><li>nested element</li></ul></li></ul>', ['* first element', '* nested element']],
 
   // See https://github.com/bustle/mobiledoc-kit/issues/333
-  ['abc\ndef', ['abc def']]
+  ['abc\ndef', ['abc def']],
+
+  // See https://github.com/bustle/mobiledoc-kit/issues/648
+  ['<div><p>first</p><p>second</p></div>', ['first', 'second']]
 ];
 
 expectations.forEach(([html, dslText]) => {

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -199,12 +199,14 @@ test("#parse handles multiple paragraphs in list item", assert => {
   parser = new SectionParser(builder);
   let sections = parser.parse(element);
 
-  assert.equal(sections.length, 1, "single list section");
+  assert.equal(sections.length, 2, '2 sections');
 
-  let list = sections[0];
-  assert.equal(list.type, "list-section");
-  assert.equal(list.items.length, 1, "1 list item");
-  assert.equal(list.items.objectAt(0).text, "OneTwo");
+  let p1 = sections[0];
+  assert.equal(p1.type, 'markup-section', 'first section type');
+  assert.equal(p1.text, 'One');
+  let p2 = sections[1];
+  assert.equal(p2.type, "markup-section", "second section type");
+  assert.equal(p2.text, "Two");
 });
 
 test("#parse handles multiple headers in list item", assert => {
@@ -216,12 +218,16 @@ test("#parse handles multiple headers in list item", assert => {
   parser = new SectionParser(builder);
   let sections = parser.parse(element);
 
-  assert.equal(sections.length, 1, "single list section");
+  assert.equal(sections.length, 2, '2 sections');
 
-  let list = sections[0];
-  assert.equal(list.type, "list-section");
-  assert.equal(list.items.length, 1, "1 list item");
-  assert.equal(list.items.objectAt(0).text, "OneTwo");
+  let h1 = sections[0];
+  assert.equal(h1.type, 'markup-section', 'first section type');
+  assert.equal(h1.text, 'One');
+  assert.equal(h1.tagName, 'h1');
+  let h2 = sections[1];
+  assert.equal(h2.type, 'markup-section', 'second section type');
+  assert.equal(h2.text, 'Two');
+  assert.equal(h2.tagName, 'h2');
 });
 
 // see https://github.com/bustle/mobiledoc-kit/issues/656

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -317,6 +317,34 @@ test('#parse avoids empty paragraph around wrapped list', (assert) => {
   assert.equal(sections.length, 1, 'single list section');
 });
 
+test('#parse handles nested lists of different types', assert => {
+  let container = buildDOM(`
+    <ol><li>One</li><li><ul><li>A</li><li>B</li></ul><li>Two</li></ol>
+  `);
+
+  let element = container.firstChild;
+  parser = new SectionParser(builder);
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 3, '3 sections');
+
+  assert.equal(sections[0].type, 'list-section', 'first section type');
+  assert.equal(sections[0].tagName, 'ol', 'first section tagName');
+  assert.equal(sections[0].items.length, 1, '1 list item in first list section');
+  assert.equal(sections[0].items.objectAt(0).text, 'One');
+
+  assert.equal(sections[1].type, 'list-section', 'second section type');
+  assert.equal(sections[1].tagName, 'ul', 'fourth section tagName');
+  assert.equal(sections[1].items.length, 2, '2 list items in second list section');
+  assert.equal(sections[1].items.objectAt(0).text, 'A');
+  assert.equal(sections[1].items.objectAt(1).text, 'B');
+
+  assert.equal(sections[2].type, 'list-section', 'third section type');
+  assert.equal(sections[2].tagName, 'ol', 'third section tagName');
+  assert.equal(sections[2].items.length, 1, '1 list item in third list section');
+  assert.equal(sections[2].items.objectAt(0).text, 'Two');
+});
+
 test('#parse handles grouping nested lists', (assert) => {
   let container = buildDOM(`
     <div><ul><li>Outer-One<ul><li>Inner-Two</li><li>Inner-Three</li></ul></li><li>Outer-Four</li></ul></div>

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -187,6 +187,36 @@ test('#parse ignores blank markup sections', assert => {
   assert.equal(sections[1].text, 'Three');
 });
 
+test('#parse handles section-level elements in list item', assert => {
+  let container = buildDOM(`
+    <ol><li>One</li><li><h4>Two</h4><p>Two - P</p></li><li>Three</li></ol>
+  `);
+
+  let element = container.firstChild;
+  parser = new SectionParser(builder);
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 4, '4 sections');
+
+  assert.equal(sections[0].type, 'list-section', 'first section type');
+  assert.equal(sections[0].tagName, 'ol', 'first section tagName');
+  assert.equal(sections[0].items.length, 1, '1 list item in first list section');
+  assert.equal(sections[0].items.objectAt(0).text, 'One');
+
+  assert.equal(sections[1].type, 'markup-section', 'second section type');
+  assert.equal(sections[1].tagName, 'h4');
+  assert.equal(sections[1].text, 'Two');
+
+  assert.equal(sections[2].type, 'markup-section', 'third section type');
+  assert.equal(sections[2].tagName, 'p');
+  assert.equal(sections[2].text, 'Two - P');
+
+  assert.equal(sections[3].type, 'list-section', 'fourth section type');
+  assert.equal(sections[3].tagName, 'ol', 'fourth section tagName');
+  assert.equal(sections[3].items.length, 1, '1 list item in last list section');
+  assert.equal(sections[3].items.objectAt(0).text, 'Three');
+});
+
 test("#parse handles single paragraph in list item", assert => {
   let container = buildDOM(`
     <ul><li><p>One</p></li>

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -267,6 +267,26 @@ test('#parse avoids empty paragraph around wrapped list', (assert) => {
   assert.equal(sections.length, 1, 'single list section');
 });
 
+test('#parse handles grouping nested lists', (assert) => {
+  let container = buildDOM(`
+    <div><ul><li>Outer-One<ul><li>Inner-Two</li><li>Inner-Three</li></ul></li><li>Outer-Four</li></ul></div>
+  `);
+
+  let element = container.firstChild;
+  parser = new SectionParser(builder);
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 1, 'single list section');
+
+  let list = sections[0];
+  assert.equal(list.type, 'list-section');
+  assert.equal(list.items.length, 4, '4 list items');
+  assert.equal(list.items.objectAt(0).text, 'Outer-One');
+  assert.equal(list.items.objectAt(1).text, 'Inner-Two');
+  assert.equal(list.items.objectAt(2).text, 'Inner-Three');
+  assert.equal(list.items.objectAt(3).text, 'Outer-Four');
+});
+
 test('#parse skips STYLE nodes', (assert) => {
   let element = buildDOM(`
     <style>.rule { font-color: red; }</style>

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -173,6 +173,20 @@ test('#parse only runs text nodes through parserPlugins once', (assert) => {
   assert.equal(pluginRunCount, 1);
 });
 
+test('#parse ignores blank markup sections', assert => {
+  let container = buildDOM(`
+    <div><p>One</p><p></p><p>Three</p></div>
+  `);
+
+  let element = container.firstChild;
+  parser = new SectionParser(builder);
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 2, 'Two sections');
+  assert.equal(sections[0].text, 'One');
+  assert.equal(sections[1].text, 'Three');
+});
+
 test("#parse handles single paragraph in list item", assert => {
   let container = buildDOM(`
     <ul><li><p>One</p></li>

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -225,35 +225,6 @@ test("#parse handles multiple headers in list item", assert => {
 });
 
 // see https://github.com/bustle/mobiledoc-kit/issues/656
-//
-// this is a minimal example of markup that was causing errors when copy/pasting
-// from Medium. The original markup stucture that was pasted looked something like this:
-//
-// <section>
-//   <div>
-//     <div>
-//       <h4>title</h4>
-//       <ul><li>one - one</li></ul>
-//       <figure><img /></figure>
-//       <ul><li>two - one</li></ul>
-//     </div>
-//   </div>
-// </section>
-// <section>
-//   <div><hr /></div>
-//   <div><div><br /></div></div>
-// </section>
-//
-// NOTE: because DOMParser passes each top-level element to SectionParser rather
-// than passing the leaf-most section with content, the SectionParser needs to
-// deal with nested wrapper elements (section->div->div->[h4,ul,figure,ul])
-//
-// the error being thrown was
-// ---
-// Uncaught TypeError: Cannot read property 'append' of undefined
-// at SectionParser._createMarker
-// ---
-// the line in question was `state.section.markers.append(marker);`
 test('#parse handles list following node handled by parserPlugin', (assert) => {
   let container = buildDOM(`
     <div><img src="https://placehold.it/100x100"><ul><li>LI One</li></ul></div>
@@ -281,6 +252,19 @@ test('#parse handles list following node handled by parserPlugin', (assert) => {
 
   let listSection = sections[1];
   assert.equal(listSection.type, 'list-section');
+  assert.equal(listSection.items.length, 1, '1 list item');
+});
+
+test('#parse avoids empty paragraph around wrapped list', (assert) => {
+  let container = buildDOM(`
+    <div><ul><li>One</li></ul></div>
+  `);
+
+  let element = container.firstChild;
+  parser = new SectionParser(builder);
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 1, 'single list section');
 });
 
 test('#parse skips STYLE nodes', (assert) => {

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -307,6 +307,37 @@ test('#parse handles grouping nested lists', (assert) => {
   assert.equal(list.items.objectAt(3).text, 'Outer-Four');
 });
 
+test('#parse handles grouping of consecutive lists of same type', (assert) => {
+  let container = buildDOM(`
+    <div><ul><li>One</li></ul><ul><li>Two</li></ul>
+  `);
+
+  let element = container.firstChild;
+  parser = new SectionParser(builder);
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 1, 'single list section');
+  let list = sections[0];
+  assert.equal(list.items.objectAt(0).text, 'One');
+  assert.equal(list.items.objectAt(1).text, 'Two');
+});
+
+test('#parse doesn\'t group consecutive lists of different types', (assert) => {
+  let container = buildDOM(`
+    <div><ul><li>One</li></ul><ol><li>Two</li></ol>
+  `);
+
+  let element = container.firstChild;
+  parser = new SectionParser(builder);
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 2, 'two list sections');
+  let ul = sections[0];
+  assert.equal(ul.items.objectAt(0).text, 'One');
+  let ol = sections[1];
+  assert.equal(ol.items.objectAt(0).text, 'Two');
+});
+
 test('#parse skips STYLE nodes', (assert) => {
   let element = buildDOM(`
     <style>.rule { font-color: red; }</style>

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -224,6 +224,65 @@ test("#parse handles multiple headers in list item", assert => {
   assert.equal(list.items.objectAt(0).text, "OneTwo");
 });
 
+// see https://github.com/bustle/mobiledoc-kit/issues/656
+//
+// this is a minimal example of markup that was causing errors when copy/pasting
+// from Medium. The original markup stucture that was pasted looked something like this:
+//
+// <section>
+//   <div>
+//     <div>
+//       <h4>title</h4>
+//       <ul><li>one - one</li></ul>
+//       <figure><img /></figure>
+//       <ul><li>two - one</li></ul>
+//     </div>
+//   </div>
+// </section>
+// <section>
+//   <div><hr /></div>
+//   <div><div><br /></div></div>
+// </section>
+//
+// NOTE: because DOMParser passes each top-level element to SectionParser rather
+// than passing the leaf-most section with content, the SectionParser needs to
+// deal with nested wrapper elements (section->div->div->[h4,ul,figure,ul])
+//
+// the error being thrown was
+// ---
+// Uncaught TypeError: Cannot read property 'append' of undefined
+// at SectionParser._createMarker
+// ---
+// the line in question was `state.section.markers.append(marker);`
+test('#parse handles list following node handled by parserPlugin', (assert) => {
+  let container = buildDOM(`
+    <div><img src="https://placehold.it/100x100"><ul><li>LI One</li></ul></div>
+  `);
+
+  let element = container.firstChild;
+  let plugins = [function(element, builder, {addSection, nodeFinished}) {
+    if (element.tagName !== 'IMG') {
+      return;
+    }
+    let payload = {url: element.src};
+    let cardSection = builder.createCardSection('test-image', payload);
+    addSection(cardSection);
+    nodeFinished();
+  }];
+
+  parser = new SectionParser(builder, { plugins });
+  const sections = parser.parse(element);
+
+  assert.equal(sections.length, 2, '2 sections');
+
+  let cardSection = sections[0];
+  assert.equal(cardSection.name, 'test-image');
+  assert.deepEqual(cardSection.payload, {url: 'https://placehold.it/100x100'});
+
+  let listSection = sections[1];
+  assert.equal(listSection.type, 'list-section');
+});
+
 test('#parse skips STYLE nodes', (assert) => {
   let element = buildDOM(`
     <style>.rule { font-color: red; }</style>

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -173,6 +173,57 @@ test('#parse only runs text nodes through parserPlugins once', (assert) => {
   assert.equal(pluginRunCount, 1);
 });
 
+test("#parse handles single paragraph in list item", assert => {
+  let container = buildDOM(`
+    <ul><li><p>One</p></li>
+  `);
+
+  let element = container.firstChild;
+  parser = new SectionParser(builder);
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 1, "single list section");
+
+  let list = sections[0];
+  assert.equal(list.type, "list-section");
+  assert.equal(list.items.length, 1, "1 list item");
+  assert.equal(list.items.objectAt(0).text, "One");
+});
+
+test("#parse handles multiple paragraphs in list item", assert => {
+  let container = buildDOM(`
+    <ul><li><p>One</p><p>Two</p></li>
+  `);
+
+  let element = container.firstChild;
+  parser = new SectionParser(builder);
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 1, "single list section");
+
+  let list = sections[0];
+  assert.equal(list.type, "list-section");
+  assert.equal(list.items.length, 1, "1 list item");
+  assert.equal(list.items.objectAt(0).text, "OneTwo");
+});
+
+test("#parse handles multiple headers in list item", assert => {
+  let container = buildDOM(`
+    <ul><li><h1>One</h1><h2>Two</h2></li>
+  `);
+
+  let element = container.firstChild;
+  parser = new SectionParser(builder);
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 1, "single list section");
+
+  let list = sections[0];
+  assert.equal(list.type, "list-section");
+  assert.equal(list.items.length, 1, "1 list item");
+  assert.equal(list.items.objectAt(0).text, "OneTwo");
+});
+
 test('#parse skips STYLE nodes', (assert) => {
   let element = buildDOM(`
     <style>.rule { font-color: red; }</style>


### PR DESCRIPTION
closes #654, closes #648 

Updates the `SectionParser` to properly close the current section and start a new one if a "section-creating" element is encountered whilst walking the node tree. This was already being handled for sections added via parser plugins but nested elements were overwriting the current section state rather than creating new sections where necessary.

Also removes the `_parseListElements` function in favour of handling list elements through `parseNode` and `_closeCurrentSection` which allows for extracting nested lists into a single top-level  list section.

Behaviour changes:
- section content with a wrapper element is no longer smushedtogether
- nested lists are treated as a single list (previous behaviour was for all text content of the nested list to be smushedtogether into a single list item)
- list items containing structural sections are parsed as structural sections rather than list items (previous behaviour was for the text content of each section in the `<li>` to be smushedtogether)
  - one exception is list elements containing a single paragraph (`<ul><li><p>content</p></li></ul>`) which will retain the list structure