### PR TITLE
WIP ignore IME key clicks

### DIFF
--- a/src/js/editor/event-manager.js
+++ b/src/js/editor/event-manager.js
@@ -166,6 +166,11 @@ export default class EventManager {
     let range = editor.range;
 
     switch(true) {
+      case key.isIME(): {
+        // For IME（eg. typing in Japanese or Korean), we want to ignore all keydowns,
+        // especially ENTER, DELETE, and TAB, which all have special behaviors in the IME popover.
+        break;
+      }
       // FIXME This should be restricted to only card/atom boundaries
       case key.isHorizontalArrowWithoutModifiersOtherThanShift(): {
         let newRange;

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -183,3 +183,18 @@ test('prevent handling newline', (assert) => {
   Helpers.dom.insertText(editor, ENTER);
   assert.postIsSimilar(editor.post, expected);
 });
+
+// These keys have meaning with the IME window so should be ignored.
+const IGNORED_IME_KEYS = [ 'Enter', 'Tab', 'ArrowLeft', 'ArrowRight', ' ', 'Backspace'];
+
+IGNORED_IME_KEYS.forEach(function(key) {
+  test(`pressing "${key}" in Input Method Editor (IME) is ignored`, (assert) => {
+    editor = Helpers.editor.buildFromText('hi|hey', {element: editorElement});
+
+    assert.hasElement('#editor p:contains(hihey)');
+
+    Helpers.dom.triggerImeKeyDown(editor, key);
+    let {post: expected} = Helpers.postAbstract.buildFromText(['hi|hey']);
+    assert.postIsSimilar(editor.post, expected, 'correctly encoded');
+  });
+});

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -176,6 +176,12 @@ function triggerEnter(editor) {
   _triggerEditorEvent(editor, event);
 }
 
+function triggerImeKeyDown(editor, key) {
+  assertEditor(editor);
+  let event = createMockEvent('keydown', editor.element, { key, keyCode: KEY_CODES.IME});
+  _triggerEditorEvent(editor, event);
+}
+
 // keyCodes and charCodes are similar but not the same.
 function keyCodeForChar(letter) {
   let keyCode;
@@ -391,6 +397,7 @@ const DOMHelper = {
   triggerDelete,
   triggerForwardDelete,
   triggerEnter,
+  triggerImeKeyDown,
   insertText,
   triggerKeyEvent,
   triggerKeyCommand,


### PR DESCRIPTION
Partial fix for #548. This fixes Korean and Japanese input (using Input Method Editor IME) for most cases. 

Editor is still broken when entering text at the beginning of a section. Still working on that. Fixing this will probably involve fixing #589, ie. don't do a full re-render when not needed. This also effects spellcheck and Android input.

Basically the keys Enter, Backspace, Space, Tab, and Arrows are all used to navigate and select within the IME editor so we want mobiledoc to ignore those.

Illustration of the bug:

**Pressing Enter**
![](http://g.recordit.co/qZRRqYjAFp.gif)

**Pressing Backspace**
 * Pressing backspace seems to duplicate the previous character
![](http://g.recordit.co/cWdgeGEiSN.gif)

**After fixed**
![](http://g.recordit.co/U0rFnhsQGE.gif)

**Still broken at start of section**
 * Notice the "w" goes straight to the document and is not part of the IME input
![](http://g.recordit.co/QUl0k467hq.gif)

