### PR TITLE
Export MOBILEDOC_VERSION from index

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -5,6 +5,7 @@ import Range from './utils/cursor/range';
 import Position from './utils/cursor/position';
 import Error from './utils/mobiledoc-error';
 import VERSION from './version';
+import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc';
 
 const Mobiledoc = {
   Editor,
@@ -13,12 +14,13 @@ const Mobiledoc = {
   Range,
   Position,
   Error,
-  VERSION
+  VERSION,
+  MOBILEDOC_VERSION
 };
 
 export function registerGlobal(global) {
   global.Mobiledoc = Mobiledoc;
 }
 
-export { Editor, UI, Range, Position };
+export { Editor, UI, Range, Position, MOBILEDOC_VERSION };
 export default Mobiledoc;


### PR DESCRIPTION
As part of modernizing the build using [Rollup.js](https://rollupjs.org/guide/en), we want Mobiledoc users to get away from importing from any module other than `mobiledoc-kit`. The one use case I've seen for other packages is that many apps do something like this:

```js
import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc';  
const EMPTY_MOBILEDOC = {
  version: MOBILEDOC_VERSION,
  //...
}`
```

Examples: [ember-yapp-mobiledoc-editor](https://github.com/lukemelia/ember-yapp-mobiledoc-editor/blob/4dddb572032ae216a2df23269b2dd4eba09d7a16/tests/dummy/app/controllers/index.js#L2), [queertangoclub](https://github.com/tim-evans/queertangoclub/blob/32564b8c4981f0112f4e2de7c52fea805ac09c81/app/components/text-editor/component.js#L4), [Ghost Admin](https://github.com/TryGhost/Ghost-Admin/blob/84059cd5a7451c5fa49f78f5209953f6bdbe5fca/lib/koenig-editor/addon/components/koenig-basic-html-input.js#L2-L7), [ember-mobiledoc-editor](https://github.com/bustle/ember-mobiledoc-editor/search?q=MOBILEDOC_VERSION&unscoped_q=MOBILEDOC_VERSION)

So to move away from there I'd like to add `MOBILEDOC_VERSION` as a named export to the `mobiledoc-kit` module so that those import states can change to `import { MOBILEDOC_VERSION } from 'mobiledoc-kit';`.

Once this PR is merged, we can open PR against those other repos.

It may also be useful to export the default `mobiledocRenderers` function but I haven't found any consumers of that yet. If we need it we can export in a separate PR.
