### PR TITLE
Fix format readme missing word

### DIFF
--- a/MOBILEDOC.md
+++ b/MOBILEDOC.md
@@ -274,7 +274,7 @@ Renders an image. In many scenarios, a card to suit your needs is better.
 
 **List section**
 
-List similar to markup sections but have a set of markers for each list item.
+Lists are similar to markup sections but have a set of markers for each list item.
 
 ```
 {


### PR DESCRIPTION
`List similar to markup section` -> `Lists are similar to markup sections`

👍

Happy to change to `List is`