### PR TITLE
Fix section parser issues

### DIFF
--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -203,7 +203,7 @@ class SectionParser {
 
         // avoid creating empty paragraphs due to wrapper elements around
         // section-creating elements
-        if (this.state.section.isMarkerable && !this.state.text) {
+        if (this.state.section.isMarkerable && !this.state.text && this.state.section.markers.length === 0) {
           this.state.section = null;
         } else {
           this._closeCurrentSection();

--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -191,7 +191,12 @@ class SectionParser {
       ) {
         // don't break out of the list for list items that contain a single <p>.
         // deals with typical case of <li><p>Text</p></li><li><p>Text</p></li>
-        if (this.state.section.isListItem && tagName === 'p' && !node.nextSibling) {
+        if (
+          this.state.section.isListItem &&
+          tagName === 'p' &&
+          !node.nextSibling &&
+          contains(VALID_LIST_ITEM_TAGNAMES, normalizeTagName(node.parentElement.tagName))
+         ) {
           this.parseElementNode(node);
           return;
         }

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -396,6 +396,24 @@ test('#parse doesn\'t group consecutive lists of different types', (assert) => {
   assert.equal(ol.items.objectAt(0).text, 'Two');
 });
 
+test('#parse handles p following list', (assert) => {
+  let container = buildDOM(`
+    <div><ol><li>li1</li><li>li2</li><p>para</p></div>
+  `);
+
+  let element = container.firstChild;
+  parser = new SectionParser(builder);
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 2, 'two sections');
+
+  let ol = sections[0];
+  assert.equal(ol.items.length, 2, 'two list items');
+
+  let p = sections[1];
+  assert.equal(p.text, 'para');
+});
+
 test('#parse skips STYLE nodes', (assert) => {
   let element = buildDOM(`
     <style>.rule { font-color: red; }</style>

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -414,6 +414,28 @@ test('#parse handles p following list', (assert) => {
   assert.equal(p.text, 'para');
 });
 
+test('#parse handles link in a heading followed by paragraph', (assert) => {
+  let container = buildDOM(`
+    <div><h4><a href="https://example.com">Linked header</a></h4><p>test</p></div>
+  `);
+
+  let element = container.firstChild;
+  parser = new SectionParser(builder);
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 2, '2 sections');
+  assert.equal(sections[0].text, 'Linked header');
+
+  let markers = sections[0].markers.toArray();
+  assert.equal(markers.length, 1, '1 marker');
+  let [marker] = markers;
+  assert.equal(marker.value, 'Linked header');
+  assert.ok(marker.hasMarkup('a'), 'has A markup');
+
+  let markup = marker.markups[0];
+  assert.equal(markup.getAttribute('href'), 'https://example.com');
+});
+
 test('#parse skips STYLE nodes', (assert) => {
   let element = buildDOM(`
     <style>.rule { font-color: red; }</style>


### PR DESCRIPTION
no issue

We found two problems with the SectionParser:

- `<ul><li>One</li></ul> <p>Two</p>`
  - would push the content of the `<p>` into the `<li>`'s ListItem section
- `<h4><a>One</a></h4> <p>Two</p>`
  - would lose the `<h4>`'s MarkupSection completely