### PR TITLE
🐛 Fixed range#expandByMarker not expanding to beginning/end of section

### DIFF
--- a/src/js/utils/cursor/range.js
+++ b/src/js/utils/cursor/range.js
@@ -141,12 +141,20 @@ class Range {
       return !detectMarker(i);
     };
 
-    let headMarker = head.section.markers.detect(firstNotMatchingDetect, head.marker, true);
-    headMarker = (headMarker && headMarker.next) || head.marker;
+    let headMarker = headSection.markers.detect(firstNotMatchingDetect, head.marker, true);
+    if (!headMarker && detectMarker(headSection.markers.head)) {
+      headMarker = headSection.markers.head;
+    } else {
+      headMarker = (headMarker && headMarker.next) || head.marker;
+    }
     let headPosition = new Position(headSection, headSection.offsetOfMarker(headMarker));
 
     let tailMarker = tail.section.markers.detect(firstNotMatchingDetect, tail.marker);
-    tailMarker = (tailMarker && tailMarker.prev) || tail.marker;
+    if (!tailMarker && detectMarker(headSection.markers.tail)) {
+      tailMarker = headSection.markers.tail;
+    } else {
+      tailMarker = (tailMarker && tailMarker.prev) || tail.marker;
+    }
     let tailPosition = new Position(tail.section, tail.section.offsetOfMarker(tailMarker) + tailMarker.length);
 
     return headPosition.toRange(tailPosition, direction);

--- a/src/js/utils/cursor/range.js
+++ b/src/js/utils/cursor/range.js
@@ -153,7 +153,7 @@ class Range {
     if (!tailMarker && detectMarker(headSection.markers.tail)) {
       tailMarker = headSection.markers.tail;
     } else {
-      tailMarker = (tailMarker && tailMarker.prev) || tail.marker;
+      tailMarker = tailMarker.prev || tail.marker;
     }
     let tailPosition = new Position(tail.section, tail.section.offsetOfMarker(tailMarker) + tailMarker.length);
 

--- a/src/js/utils/cursor/range.js
+++ b/src/js/utils/cursor/range.js
@@ -145,7 +145,7 @@ class Range {
     if (!headMarker && detectMarker(headSection.markers.head)) {
       headMarker = headSection.markers.head;
     } else {
-      headMarker = (headMarker && headMarker.next) || head.marker;
+      headMarker = headMarker.next || head.marker;
     }
     let headPosition = new Position(headSection, headSection.offsetOfMarker(headMarker));
 

--- a/tests/unit/utils/cursor-range-test.js
+++ b/tests/unit/utils/cursor-range-test.js
@@ -220,3 +220,68 @@ test('#expandByMarker processed markers in a callback and continues as long as t
     'range tail did not change'
   );
 });
+
+// https://github.com/bustle/mobiledoc-kit/issues/676
+test('#expandByMarker can expand to beginning of section with matching markups', (assert) => {
+  let post = Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
+    let bold = markup('b');
+    let italic = markup('i');
+    return post([
+      markupSection('p', [
+        marker('aiya', [bold]),
+        marker('biya', [bold, italic]),
+        marker('ciya', [bold]),
+        marker('diya', [bold]),
+      ])
+    ]);
+  });
+
+  let section = post.sections.head;
+  let head = section.toPosition(14); // i in 4th hiya
+  let tail = section.toPosition(14); // i in 4th hiya
+  let range = head.toRange(tail);
+  let expandedRange = range.expandByMarker(marker => {
+    return !!(detect(marker.markups, markup => markup.tagName === 'b'));
+  });
+
+  assert.positionIsEqual(
+    expandedRange.head, section.toPosition(0),
+    'range head is start of first marker'
+  );
+  assert.positionIsEqual(
+    expandedRange.tail, section.toPosition(16),
+    'range tail is at end of last marker'
+  );
+});
+
+test('#expandByMarker can expand to end of section with matching markups', (assert) => {
+  let post = Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
+    let bold = markup('b');
+    let italic = markup('i');
+    return post([
+      markupSection('p', [
+        marker('aiya', [bold]),
+        marker('biya', [bold, italic]),
+        marker('ciya', [bold]),
+        marker('diya', [bold]),
+      ])
+    ]);
+  });
+
+  let section = post.sections.head;
+  let head = section.toPosition(2); // i in 4th hiya
+  let tail = section.toPosition(2); // i in 4th hiya
+  let range = head.toRange(tail);
+  let expandedRange = range.expandByMarker(marker => {
+    return !!(detect(marker.markups, markup => markup.tagName === 'b'));
+  });
+
+  assert.positionIsEqual(
+    expandedRange.head, section.toPosition(0),
+    'range head is start of first marker'
+  );
+  assert.positionIsEqual(
+    expandedRange.tail, section.toPosition(16),
+    'range tail is at end of last marker'
+  );
+});


### PR DESCRIPTION
closes https://github.com/bustle/mobiledoc-kit/issues/676
- after failing to find a non-matching marker, perform a check for the first/last markers in the range's section matching the supplied detection callback. If it does match we can assume that we checked all markers in that direction so we expand to the beginning/end of the section
- improves behaviour to match the documentation: "expand a range to all markers matching a given check"