### PR TITLE
🐛 Fixed atoms with no text value being removed when parsing top-level markerables

### DIFF
--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -16,6 +16,7 @@ import {
   normalizeTagName
 } from '../utils/dom-utils';
 import {
+  any,
   detect,
   forEach
 } from '../utils/array-utils';
@@ -128,7 +129,12 @@ class DOMParser {
   }
 
   appendSection(post, section) {
-    if (section.isBlank || (section.isMarkerable && trim(section.text) === '')) {
+    if (
+      section.isBlank ||
+      (section.isMarkerable &&
+        trim(section.text) === "" &&
+        !any(section.markers, marker => marker.isAtom))
+    ) {
       return;
     }
 

--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -30,6 +30,7 @@ import {
 } from 'mobiledoc-kit/utils/dom-utils';
 
 import {
+  any,
   forEach,
   contains
 } from 'mobiledoc-kit/utils/array-utils';
@@ -288,7 +289,11 @@ class SectionParser {
       lastSection.items.append(state.section);
     } else {
       // avoid creating empty markup sections, especially useful for indented source
-      if (state.section.isMarkerable && !state.section.text.trim()) {
+      if (
+        state.section.isMarkerable &&
+        !state.section.text.trim() &&
+        !any(state.section.markers, marker => marker.isAtom)
+      ) {
         state.section = null;
         state.text = '';
         return;

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -397,3 +397,29 @@ test('lis in nested uls are flattened (when ul is child of ul)', (assert) => {
   assert.equal(section.items.objectAt(1).text, 'inner');
 });
 
+test('#appendSection does not skip sections containing a single atom with no text value', (assert) => {
+  let options = {
+    plugins: [function (node, builder, {addMarkerable, nodeFinished}) {
+      if (node.nodeType !== 1 || node.tagName !== 'BR') {
+          return;
+      }
+
+      let softReturn = builder.createAtom('soft-return');
+      addMarkerable(softReturn);
+
+      nodeFinished();
+    }]
+  };
+  parser = new DOMParser(builder, options);
+
+  let element = buildDOM(`Testing<br>Atoms`);
+  const post = parser.parse(element);
+
+  assert.equal(post.sections.length, 1, '1 section');
+  let section = post.sections.objectAt(0);
+  assert.equal(section.tagName, 'p');
+  assert.equal(section.markers.length, 3, '3 markers');
+  assert.equal(section.markers.objectAt(0).value, 'Testing');
+  assert.equal(section.markers.objectAt(1).name, 'soft-return');
+  assert.equal(section.markers.objectAt(2).value, 'Atoms');
+});


### PR DESCRIPTION
no issue

- the "empty section" skips in the section and dom parsers were a little too over-zealous and were skipping over no-text atoms such as a soft-breaks that were created by parser plugins