### PR TITLE
🐛 Fixed parser plugin handling of top-level comment nodes

### DIFF
--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -615,3 +615,41 @@ test('#parse handles <p> inside <blockquote>', (assert) => {
   assert.equal(sections[1].tagName, 'blockquote');
   assert.equal(sections[1].text.trim(), 'Two');
 });
+
+test('#parse allows top-level Comment nodes to be parsed by parser plugins', (assert) => {
+  let element = buildDOM(`<!--parse me-->`).firstChild;
+  let plugins = [function(element, builder, {addMarkerable}) {
+    if (element.nodeType !== 8 && element.nodeValue !== 'parse me') {
+      return;
+    }
+    let marker = builder.createMarker('oh my');
+    addMarkerable(marker);
+  }];
+
+  parser = new SectionParser(builder, {plugins});
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 1);
+  let [section] = sections;
+  assert.equal(section.text, 'oh my', 'parses comment with parser plugin');
+  assert.equal(section.markers.length, 1, 'only 1 marker');
+});
+
+test('#parse allows nested Comment nodes to be parsed by parser plugins', (assert) => {
+  let element = buildDOM(`<p><!--parse me--></p>`).firstChild;
+  let plugins = [function(element, builder, {addMarkerable}) {
+    if (element.nodeType !== 8 && element.nodeValue !== 'parse me') {
+      return;
+    }
+    let marker = builder.createMarker('oh my');
+    addMarkerable(marker);
+  }];
+
+  parser = new SectionParser(builder, {plugins});
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 1);
+  let [section] = sections;
+  assert.equal(section.text, 'oh my', 'parses comment with parser plugin');
+  assert.equal(section.markers.length, 1, 'only 1 marker');
+});


### PR DESCRIPTION
no issue

- the section parser allows comment nodes to be parsed by parser plugins but due to top-level comment nodes being skipped it meant that they wouldn't be seen in certain circumstances
- removes the top-level skip of comment nodes so that they will be passed through the parser plugins
- adds specific skips for comment nodes in areas that create/update state from elements
- allows for `addMarkerable` to be called by a parser plugin when no state has been set up yet such as in the case where the first element in a parsed section is a comment node that is handled by a parser plugin

We ran into this issue at Ghost, the specific situation may be a little out of the ordinary so I'll add it here for context. When we render cards we add begin/end comments around the card's rendered html, eg:

```html
<p>General mobiledoc output...</p>

<!--kg-card-begin: html-->
<div class="my-custom-html">....</div>
<!--hg-card-end: html-->

<p>More mobiledoc  output...</p>
```

This allows us to use mobiledoc parser plugins to extract unknown HTML content into a card's payload where it would normally be thrown away by the parser because it doesn't directly map to mobiledoc-supported HTML. We used comments because we didn't want to add extra markup around content that could affect styling or functionality, comments allowed us to add the card-boundary rendering in a backwards-compatible way.