### PR TITLE
Implement Mobiledoc 0.3.2 (text alignment attribute)

### DIFF
--- a/src/js/models/_attributable.js
+++ b/src/js/models/_attributable.js
@@ -1,0 +1,25 @@
+export const VALID_ATTRIBUTES = [
+  'data-md-text-align'
+];
+
+/*
+ * A "mixin" to add section attribute support
+ * to markup and list sections.
+ */
+export function attributable(ctx) {
+  ctx.attributes = {};
+
+  ctx.setAttribute = (key, value) => {
+    if (!VALID_ATTRIBUTES.includes(key)) {
+      throw new Error(`Invalid attribute "${key}" was passed. Constrain attributes to the spec-compliant whitelist.`);
+    }
+    ctx.attributes[key] = value;
+  };
+  ctx.removeAttribute = key => {
+    delete ctx.attributes[key];
+  };
+  ctx.getAttribute = key => ctx.attributes[key];
+  ctx.eachAttribute = cb => {
+    Object.entries(ctx.attributes).forEach(([k,v]) => cb(k,v));
+  };
+}

--- a/src/js/models/list-section.js
+++ b/src/js/models/list-section.js
@@ -4,6 +4,7 @@ import { LIST_SECTION_TYPE } from './types';
 import Section from './_section';
 import { normalizeTagName } from '../utils/dom-utils';
 import assert from '../utils/assert';
+import { attributable } from './_attributable';
 
 export const VALID_LIST_SECTION_TAGNAMES = [
   'ul', 'ol'
@@ -12,11 +13,14 @@ export const VALID_LIST_SECTION_TAGNAMES = [
 export const DEFAULT_TAG_NAME = VALID_LIST_SECTION_TAGNAMES[0];
 
 export default class ListSection extends Section {
-  constructor(tagName=DEFAULT_TAG_NAME, items=[]) {
+  constructor(tagName=DEFAULT_TAG_NAME, items=[], attributes={}) {
     super(LIST_SECTION_TYPE);
     this.tagName = tagName;
     this.isListSection = true;
     this.isLeafSection = false;
+
+    attributable(this);
+    Object.entries(attributes).forEach(([k,v]) => this.setAttribute(k, v));
 
     this.items = new LinkedList({
       adoptItem: i => {

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -2,6 +2,7 @@ import Markerable from './_markerable';
 import { normalizeTagName } from '../utils/dom-utils';
 import { contains } from '../utils/array-utils';
 import { MARKUP_SECTION_TYPE } from './types';
+import { attributable } from './_attributable';
 
 // valid values of `tagName` for a MarkupSection
 export const VALID_MARKUP_SECTION_TAGNAMES = [
@@ -33,8 +34,12 @@ export const MARKUP_SECTION_ELEMENT_NAMES = [
 export const DEFAULT_TAG_NAME = VALID_MARKUP_SECTION_TAGNAMES[8];
 
 const MarkupSection = class MarkupSection extends Markerable {
-  constructor(tagName=DEFAULT_TAG_NAME, markers=[]) {
+  constructor(tagName=DEFAULT_TAG_NAME, markers=[], attributes={}) {
     super(MARKUP_SECTION_TYPE, tagName, markers);
+
+    attributable(this);
+    Object.entries(attributes).forEach(([k,v]) => this.setAttribute(k, v));
+
     this.isMarkupSection = true;
   }
 

--- a/src/js/models/post-node-builder.js
+++ b/src/js/models/post-node-builder.js
@@ -78,9 +78,9 @@ class PostNodeBuilder {
    * @param {Marker[]} [markers=[]]
    * @return {MarkupSection}
    */
-  createMarkupSection(tagName=DEFAULT_MARKUP_SECTION_TAG_NAME, markers=[], isGenerated=false) {
+  createMarkupSection(tagName=DEFAULT_MARKUP_SECTION_TAG_NAME, markers=[], isGenerated=false, attributes={}) {
     tagName = normalizeTagName(tagName);
-    const section = new MarkupSection(tagName, markers);
+    const section = new MarkupSection(tagName, markers, attributes);
     if (isGenerated) {
       section.isGenerated = true;
     }
@@ -88,9 +88,9 @@ class PostNodeBuilder {
     return section;
   }
 
-  createListSection(tagName=DEFAULT_LIST_SECTION_TAG_NAME, items=[]) {
+  createListSection(tagName=DEFAULT_LIST_SECTION_TAG_NAME, items=[], attributes={}) {
     tagName = normalizeTagName(tagName);
-    const section = new ListSection(tagName, items);
+    const section = new ListSection(tagName, items, attributes);
     section.builder = this;
     return section;
   }

--- a/src/js/parsers/mobiledoc/0-3-2.js
+++ b/src/js/parsers/mobiledoc/0-3-2.js
@@ -1,0 +1,176 @@
+import {
+  MOBILEDOC_MARKUP_SECTION_TYPE,
+  MOBILEDOC_IMAGE_SECTION_TYPE,
+  MOBILEDOC_LIST_SECTION_TYPE,
+  MOBILEDOC_CARD_SECTION_TYPE,
+  MOBILEDOC_MARKUP_MARKER_TYPE,
+  MOBILEDOC_ATOM_MARKER_TYPE
+} from 'mobiledoc-kit/renderers/mobiledoc/0-3-2';
+import { kvArrayToObject, filter } from "../../utils/array-utils";
+import assert from 'mobiledoc-kit/utils/assert';
+
+/*
+ * Parses from mobiledoc -> post
+ */
+export default class MobiledocParser {
+  constructor(builder) {
+    this.builder = builder;
+  }
+
+  /**
+   * @param {Mobiledoc}
+   * @return {Post}
+   */
+  parse({ sections, markups: markerTypes, cards: cardTypes, atoms: atomTypes }) {
+    try {
+      const post = this.builder.createPost();
+
+      this.markups = [];
+      this.markerTypes = this.parseMarkerTypes(markerTypes);
+      this.cardTypes = this.parseCardTypes(cardTypes);
+      this.atomTypes = this.parseAtomTypes(atomTypes);
+      this.parseSections(sections, post);
+
+      return post;
+    } catch (e) {
+      assert(`Unable to parse mobiledoc: ${e.message}`, false);
+    }
+  }
+
+  parseMarkerTypes(markerTypes) {
+    return markerTypes.map((markerType) => this.parseMarkerType(markerType));
+  }
+
+  parseMarkerType([tagName, attributesArray]) {
+    const attributesObject = kvArrayToObject(attributesArray || []);
+    return this.builder.createMarkup(tagName, attributesObject);
+  }
+
+  parseCardTypes(cardTypes) {
+    return cardTypes.map((cardType) => this.parseCardType(cardType));
+  }
+
+  parseCardType([cardName, cardPayload]) {
+    return [cardName, cardPayload];
+  }
+
+  parseAtomTypes(atomTypes) {
+    return atomTypes.map((atomType) => this.parseAtomType(atomType));
+  }
+
+  parseAtomType([atomName, atomValue, atomPayload]) {
+    return [atomName, atomValue, atomPayload];
+  }
+
+  parseSections(sections, post) {
+    sections.forEach((section) => this.parseSection(section, post));
+  }
+
+  parseSection(section, post) {
+    let [type] = section;
+    switch(type) {
+      case MOBILEDOC_MARKUP_SECTION_TYPE:
+        this.parseMarkupSection(section, post);
+        break;
+      case MOBILEDOC_IMAGE_SECTION_TYPE:
+        this.parseImageSection(section, post);
+        break;
+      case MOBILEDOC_CARD_SECTION_TYPE:
+        this.parseCardSection(section, post);
+        break;
+      case MOBILEDOC_LIST_SECTION_TYPE:
+        this.parseListSection(section, post);
+        break;
+      default:
+        assert('Unexpected section type ${type}', false);
+    }
+  }
+
+  getAtomTypeFromIndex(index) {
+    const atomType = this.atomTypes[index];
+    assert(`No atom definition found at index ${index}`, !!atomType);
+    return atomType;
+  }
+
+  getCardTypeFromIndex(index) {
+    const cardType = this.cardTypes[index];
+    assert(`No card definition found at index ${index}`, !!cardType);
+    return cardType;
+  }
+
+  parseCardSection([, cardIndex], post) {
+    const [name, payload] = this.getCardTypeFromIndex(cardIndex);
+    const section = this.builder.createCardSection(name, payload);
+    post.sections.append(section);
+  }
+
+  parseImageSection([, src], post) {
+    const section = this.builder.createImageSection(src);
+    post.sections.append(section);
+  }
+
+  parseMarkupSection([, tagName, markers, attributesArray], post) {
+    const section = this.builder.createMarkupSection(tagName);
+    post.sections.append(section);
+    if (attributesArray) {
+      Object.entries(kvArrayToObject(attributesArray)).forEach(([key, value]) => {
+        section.setAttribute(key, value);
+      });
+    }
+    this.parseMarkers(markers, section);
+    // Strip blank markers after they have been created. This ensures any
+    // markup they include has been correctly populated.
+    filter(section.markers, m => m.isBlank).forEach(m => {
+      section.markers.remove(m);
+    });
+  }
+
+  parseListSection([, tagName, items, attributesArray], post) {
+    const section = this.builder.createListSection(tagName);
+    post.sections.append(section);
+    if (attributesArray) {
+      Object.entries(kvArrayToObject(attributesArray)).forEach(([key, value]) => {
+        section.setAttribute(key, value);
+      });
+    }
+    this.parseListItems(items, section);
+  }
+
+  parseListItems(items, section) {
+    items.forEach(i => this.parseListItem(i, section));
+  }
+
+  parseListItem(markers, section) {
+    const item = this.builder.createListItem();
+    this.parseMarkers(markers, item);
+    section.items.append(item);
+  }
+
+  parseMarkers(markers, parent) {
+    markers.forEach(m => this.parseMarker(m, parent));
+  }
+
+  parseMarker([type, markerTypeIndexes, closeCount, value], parent) {
+    markerTypeIndexes.forEach(index => {
+      this.markups.push(this.markerTypes[index]);
+    });
+
+    const marker = this.buildMarkerType(type, value);
+    parent.markers.append(marker);
+
+    this.markups = this.markups.slice(0, this.markups.length-closeCount);
+  }
+
+  buildMarkerType(type, value) {
+    switch (type) {
+      case MOBILEDOC_MARKUP_MARKER_TYPE:
+        return this.builder.createMarker(value, this.markups.slice());
+      case MOBILEDOC_ATOM_MARKER_TYPE: {
+        const [atomName, atomValue, atomPayload] = this.getAtomTypeFromIndex(value);
+        return this.builder.createAtom(atomName, atomValue, atomPayload, this.markups.slice());
+      }
+      default:
+        assert(`Unexpected marker type ${type}`, false);
+    }
+  }
+}

--- a/src/js/parsers/mobiledoc/index.js
+++ b/src/js/parsers/mobiledoc/index.js
@@ -1,10 +1,12 @@
 import MobiledocParser_0_2 from './0-2';
 import MobiledocParser_0_3 from './0-3';
 import MobiledocParser_0_3_1 from './0-3-1';
+import MobiledocParser_0_3_2 from './0-3-2';
 
 import { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_2 } from 'mobiledoc-kit/renderers/mobiledoc/0-2';
 import { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_3 } from 'mobiledoc-kit/renderers/mobiledoc/0-3';
 import { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_3_1 } from 'mobiledoc-kit/renderers/mobiledoc/0-3-1';
+import { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_3_2 } from 'mobiledoc-kit/renderers/mobiledoc/0-3-2';
 import assert from 'mobiledoc-kit/utils/assert';
 
 function parseVersion(mobiledoc) {
@@ -21,6 +23,8 @@ export default {
         return new MobiledocParser_0_3(builder).parse(mobiledoc);
       case MOBILEDOC_VERSION_0_3_1:
         return new MobiledocParser_0_3_1(builder).parse(mobiledoc);
+      case MOBILEDOC_VERSION_0_3_2:
+        return new MobiledocParser_0_3_2(builder).parse(mobiledoc);
       default:
         assert(`Unknown version of mobiledoc parser requested: ${version}`,
                false);

--- a/src/js/renderers/editor-dom.js
+++ b/src/js/renderers/editor-dom.js
@@ -88,11 +88,21 @@ function renderMarkupSection(section) {
     addClassName(element, section.tagName);
   }
 
+  section.eachAttribute((key, value) => {
+    element.style.setProperty(key.replace('data-md-',''), value);
+  });
+
   return element;
 }
 
 function renderListSection(section) {
-  return document.createElement(section.tagName);
+  let element = document.createElement(section.tagName);
+
+  section.eachAttribute((key, value) => {
+    element.style.setProperty(key.replace('data-md-',''), value);
+  });
+
+  return element;
 }
 
 function renderListItem() {

--- a/src/js/renderers/mobiledoc/0-3-2.js
+++ b/src/js/renderers/mobiledoc/0-3-2.js
@@ -1,0 +1,159 @@
+import {visit, visitArray, compile} from '../../utils/compiler';
+import { objectToSortedKVArray } from '../../utils/array-utils';
+import {
+  POST_TYPE,
+  MARKUP_SECTION_TYPE,
+  LIST_SECTION_TYPE,
+  LIST_ITEM_TYPE,
+  MARKER_TYPE,
+  MARKUP_TYPE,
+  IMAGE_SECTION_TYPE,
+  CARD_TYPE,
+  ATOM_TYPE
+} from '../../models/types';
+
+export const MOBILEDOC_VERSION = '0.3.2';
+export const MOBILEDOC_MARKUP_SECTION_TYPE = 1;
+export const MOBILEDOC_IMAGE_SECTION_TYPE = 2;
+export const MOBILEDOC_LIST_SECTION_TYPE = 3;
+export const MOBILEDOC_CARD_SECTION_TYPE = 10;
+
+export const MOBILEDOC_MARKUP_MARKER_TYPE = 0;
+export const MOBILEDOC_ATOM_MARKER_TYPE = 1;
+
+const visitor = {
+  [POST_TYPE](node, opcodes) {
+    opcodes.push(['openPost']);
+    visitArray(visitor, node.sections, opcodes);
+  },
+  [MARKUP_SECTION_TYPE](node, opcodes) {
+    opcodes.push(['openMarkupSection', node.tagName, objectToSortedKVArray(node.attributes)]);
+    visitArray(visitor, node.markers, opcodes);
+  },
+  [LIST_SECTION_TYPE](node, opcodes) {
+    opcodes.push(['openListSection', node.tagName, objectToSortedKVArray(node.attributes)]);
+    visitArray(visitor, node.items, opcodes);
+  },
+  [LIST_ITEM_TYPE](node, opcodes) {
+    opcodes.push(['openListItem']);
+    visitArray(visitor, node.markers, opcodes);
+  },
+  [IMAGE_SECTION_TYPE](node, opcodes) {
+    opcodes.push(['openImageSection', node.src]);
+  },
+  [CARD_TYPE](node, opcodes) {
+    opcodes.push(['openCardSection', node.name, node.payload]);
+  },
+  [MARKER_TYPE](node, opcodes) {
+    opcodes.push(['openMarker', node.closedMarkups.length, node.value]);
+    visitArray(visitor, node.openedMarkups, opcodes);
+  },
+  [MARKUP_TYPE](node, opcodes) {
+    opcodes.push(['openMarkup', node.tagName, objectToSortedKVArray(node.attributes)]);
+  },
+  [ATOM_TYPE](node, opcodes) {
+    opcodes.push(['openAtom', node.closedMarkups.length, node.name, node.value, node.payload]);
+    visitArray(visitor, node.openedMarkups, opcodes);
+  }
+};
+
+const postOpcodeCompiler = {
+  openMarker(closeCount, value) {
+    this.markupMarkerIds = [];
+    this.markers.push([
+      MOBILEDOC_MARKUP_MARKER_TYPE,
+      this.markupMarkerIds,
+      closeCount,
+      value || ''
+    ]);
+  },
+  openMarkupSection(tagName, attributes) {
+    this.markers = [];
+    this.sections.push([MOBILEDOC_MARKUP_SECTION_TYPE, tagName, this.markers, attributes]);
+  },
+  openListSection(tagName, attributes) {
+    this.items = [];
+    this.sections.push([MOBILEDOC_LIST_SECTION_TYPE, tagName, this.items, attributes]);
+  },
+  openListItem() {
+    this.markers = [];
+    this.items.push(this.markers);
+  },
+  openImageSection(url) {
+    this.sections.push([MOBILEDOC_IMAGE_SECTION_TYPE, url]);
+  },
+  openCardSection(name, payload) {
+    const index = this._addCardTypeIndex(name, payload);
+    this.sections.push([MOBILEDOC_CARD_SECTION_TYPE, index]);
+  },
+  openAtom(closeCount, name, value, payload) {
+    const index = this._addAtomTypeIndex(name, value, payload);
+    this.markupMarkerIds = [];
+    this.markers.push([
+      MOBILEDOC_ATOM_MARKER_TYPE,
+      this.markupMarkerIds,
+      closeCount,
+      index
+    ]);
+  },
+  openPost() {
+    this.atomTypes = [];
+    this.cardTypes = [];
+    this.markerTypes = [];
+    this.sections = [];
+    this.result = {
+      version: MOBILEDOC_VERSION,
+      atoms: this.atomTypes,
+      cards: this.cardTypes,
+      markups: this.markerTypes,
+      sections: this.sections
+    };
+  },
+  openMarkup(tagName, attributes) {
+    const index = this._findOrAddMarkerTypeIndex(tagName, attributes);
+    this.markupMarkerIds.push(index);
+  },
+  _addCardTypeIndex(cardName, payload) {
+    let cardType = [cardName, payload];
+    this.cardTypes.push(cardType);
+    return this.cardTypes.length - 1;
+  },
+  _addAtomTypeIndex(atomName, atomValue, payload) {
+    let atomType = [atomName, atomValue, payload];
+    this.atomTypes.push(atomType);
+    return this.atomTypes.length - 1;
+  },
+  _findOrAddMarkerTypeIndex(tagName, attributesArray) {
+    if (!this._markerTypeCache) { this._markerTypeCache = {}; }
+    const key = `${tagName}-${attributesArray.join('-')}`;
+
+    let index = this._markerTypeCache[key];
+    if (index === undefined) {
+      let markerType = [tagName];
+      if (attributesArray.length) { markerType.push(attributesArray); }
+      this.markerTypes.push(markerType);
+
+      index =  this.markerTypes.length - 1;
+      this._markerTypeCache[key] = index;
+    }
+
+    return index;
+  }
+};
+
+/**
+ * Render from post -> mobiledoc
+ */
+export default {
+  /**
+   * @param {Post}
+   * @return {Mobiledoc}
+   */
+  render(post) {
+    let opcodes = [];
+    visit(visitor, post, opcodes);
+    let compiler = Object.create(postOpcodeCompiler);
+    compile(compiler, opcodes);
+    return compiler.result;
+  }
+};

--- a/src/js/renderers/mobiledoc/index.js
+++ b/src/js/renderers/mobiledoc/index.js
@@ -1,9 +1,10 @@
 import MobiledocRenderer_0_2, { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_2 } from './0-2';
 import MobiledocRenderer_0_3, { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_3 } from './0-3';
 import MobiledocRenderer_0_3_1, { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_3_1 } from './0-3-1';
+import MobiledocRenderer_0_3_2, { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_3_2 } from './0-3-2';
 import assert from 'mobiledoc-kit/utils/assert';
 
-export const MOBILEDOC_VERSION = MOBILEDOC_VERSION_0_3_1;
+export const MOBILEDOC_VERSION = MOBILEDOC_VERSION_0_3_2;
 
 export default {
   render(post, version) {
@@ -12,10 +13,12 @@ export default {
         return MobiledocRenderer_0_2.render(post);
       case MOBILEDOC_VERSION_0_3:
         return MobiledocRenderer_0_3.render(post);
-      case undefined:
-      case null:
       case MOBILEDOC_VERSION_0_3_1:
         return MobiledocRenderer_0_3_1.render(post);
+      case undefined:
+      case null:
+      case MOBILEDOC_VERSION_0_3_2:
+        return MobiledocRenderer_0_3_2.render(post);
       default:
         assert(`Unknown version of mobiledoc renderer requested: ${version}`, false);
     }

--- a/tests/acceptance/editor-list-test.js
+++ b/tests/acceptance/editor-list-test.js
@@ -448,3 +448,18 @@ test('selecting list item and deleting leaves following section intact', (assert
   assert.hasNoElement('#editor li:contains(abc)', 'li text is removed');
   assert.hasElement('#editor li:contains(X)', 'text is inserted');
 });
+
+test('list sections may contain attributes', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(({post, listSection, listItem, marker}) => {
+    return post([
+      listSection('ul', [
+        listItem([marker('abc')]), listItem()
+      ], {'data-md-text-align': 'center'})
+    ]);
+  });
+
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+
+  assert.hasElement('#editor ul[style="text-align: center;"]');
+});

--- a/tests/acceptance/editor-post-editor-test.js
+++ b/tests/acceptance/editor-post-editor-test.js
@@ -265,3 +265,16 @@ test('postEditor reads editor range, sets it with #setRange', (assert) => {
 
   assert.ok(editor.range.isEqual(newRange), 'newRange is rendered after run');
 });
+
+test('markup sections may contain attributes', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
+    return post([
+      markupSection('p', [marker('123')], false, {'data-md-text-align': 'center'})
+    ]);
+  });
+
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+
+  assert.hasElement('#editor p[style="text-align: center;"]');
+});

--- a/tests/helpers/mobiledoc.js
+++ b/tests/helpers/mobiledoc.js
@@ -3,6 +3,7 @@ import mobiledocRenderers from 'mobiledoc-kit/renderers/mobiledoc';
 import MobiledocRenderer_0_2, { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_2 } from 'mobiledoc-kit/renderers/mobiledoc/0-2';
 import MobiledocRenderer_0_3, { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_3 } from 'mobiledoc-kit/renderers/mobiledoc/0-3';
 import MobiledocRenderer_0_3_1, { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_3_1 } from 'mobiledoc-kit/renderers/mobiledoc/0-3-1';
+import MobiledocRenderer_0_3_2, { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_3_2 } from 'mobiledoc-kit/renderers/mobiledoc/0-3-2';
 import Editor from 'mobiledoc-kit/editor/editor';
 import Range from 'mobiledoc-kit/utils/cursor/range';
 import { mergeWithOptions } from 'mobiledoc-kit/utils/merge';
@@ -27,6 +28,8 @@ function build(treeFn, version) {
       return MobiledocRenderer_0_3.render(post);
     case MOBILEDOC_VERSION_0_3_1:
       return MobiledocRenderer_0_3_1.render(post);
+    case MOBILEDOC_VERSION_0_3_2:
+      return MobiledocRenderer_0_3_2.render(post);
     case undefined:
     case null:
       return mobiledocRenderers.render(post);

--- a/tests/helpers/sections.js
+++ b/tests/helpers/sections.js
@@ -1,0 +1,11 @@
+export const VALID_ATTRIBUTES = [
+  { key: 'data-md-text-align', value: 'center' },
+  { key: 'data-md-text-align', value: 'justify' },
+  { key: 'data-md-text-align', value: 'left' },
+  { key: 'data-md-text-align', value: 'right' }
+];
+
+export const INVALID_ATTRIBUTES = [
+  { key: 'data-foo', value: 'baz' }
+];
+

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -189,6 +189,9 @@ test('#serialize serializes to MOBILEDOC_VERSION by default', (assert) => {
   let mobiledoc3_1 = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
     return post([markupSection('p', [marker('abc')])]);
   }, '0.3.1');
+  let mobiledoc3_2 = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  }, '0.3.2');
 
   editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
     return post([markupSection('p', [marker('abc')])]);
@@ -197,7 +200,8 @@ test('#serialize serializes to MOBILEDOC_VERSION by default', (assert) => {
   assert.deepEqual(editor.serialize('0.2.0'), mobiledoc2, 'serializes 0.2.0');
   assert.deepEqual(editor.serialize('0.3.0'), mobiledoc3, 'serializes 0.3.0');
   assert.deepEqual(editor.serialize('0.3.1'), mobiledoc3_1, 'serializes 0.3.1');
-  assert.deepEqual(editor.serialize(), mobiledoc3_1, 'serializes 0.3.1 by default');
+  assert.deepEqual(editor.serialize('0.3.2'), mobiledoc3_2, 'serializes 0.3.2');
+  assert.deepEqual(editor.serialize(), mobiledoc3_2, 'serializes 0.3.2 by default');
 
   assert.throws(
     () => editor.serialize('unknown'),

--- a/tests/unit/models/list-section-test.js
+++ b/tests/unit/models/list-section-test.js
@@ -1,5 +1,6 @@
 import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
 import TestHelpers from '../../test-helpers';
+import { VALID_ATTRIBUTES, INVALID_ATTRIBUTES } from '../../helpers/sections';
 
 const {module, test} = TestHelpers;
 
@@ -13,6 +14,27 @@ module('Unit: List Section', {
   }
 });
 
+for (let attribute of VALID_ATTRIBUTES) {
+  // eslint-disable-next-line no-loop-func
+  test(`a section can have attribute "${attribute.key}" with value "${attribute.value}`, (assert) => {
+    const s1 = builder.createListSection('ol', [], { [attribute.key]: attribute.value });
+    assert.deepEqual(
+      s1.attributes,
+      { [attribute.key]: attribute.value },
+      'Attribute set at instantiation'
+    );
+  });
+}
+
+for (let attribute of INVALID_ATTRIBUTES) {
+  // eslint-disable-next-line no-loop-func
+  test(`a section throws when invalid attribute "${attribute.key}" is passed to a marker`, (assert) => {
+    assert.throws(() => {
+      builder.createListSection('ul', [], { [attribute.key]: attribute.value });
+    });
+  });
+}
+
 test('cloning a list section creates the same type of list section', (assert) => {
   let item = builder.createListItem([builder.createMarker('abc')]);
   let list = builder.createListSection('ol', [item]);
@@ -22,3 +44,4 @@ test('cloning a list section creates the same type of list section', (assert) =>
   assert.equal(list.items.length, cloned.items.length);
   assert.equal(list.items.head.text, cloned.items.head.text);
 });
+

--- a/tests/unit/models/markup-section-test.js
+++ b/tests/unit/models/markup-section-test.js
@@ -1,6 +1,7 @@
 import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
 import Helpers from '../../test-helpers';
 import Position from 'mobiledoc-kit/utils/cursor/position';
+import { VALID_ATTRIBUTES, INVALID_ATTRIBUTES } from '../../helpers/sections';
 
 const {module, test} = Helpers;
 
@@ -21,6 +22,27 @@ test('a section can append a marker', (assert) => {
   s1.markers.append(m1);
   assert.equal(s1.markers.length, 1);
 });
+
+for (let attribute of VALID_ATTRIBUTES) {
+  // eslint-disable-next-line no-loop-func
+  test(`a section can have attribute "${attribute.key}" with value "${attribute.value}`, (assert) => {
+    const s1 = builder.createMarkupSection('P', [], false, { [attribute.key]: attribute.value });
+    assert.deepEqual(
+      s1.attributes,
+      { [attribute.key]: attribute.value },
+      'Attribute set at instantiation'
+    );
+  });
+}
+
+for (let attribute of INVALID_ATTRIBUTES) {
+  // eslint-disable-next-line no-loop-func
+  test(`a section throws when invalid attribute "${attribute.key}" is passed to a marker`, (assert) => {
+    assert.throws(() => {
+      builder.createMarkupSection('P', [], false, attribute);
+    });
+  });
+}
 
 test('#isBlank returns true if the text length is zero for two markers', (assert) => {
   const m1 = builder.createMarker('');


### PR DESCRIPTION
Iterates upon https://github.com/bustle/mobiledoc-kit/pull/670

Spec change is described in https://github.com/bustle/mobiledoc-kit/pull/681

TODO:
* [ ] Bump mobiledoc-dom-renderer
* [x] Add an actual API to the models instead of manipulating `.attributes` (done, see `_attributable`)
* [ ] Add an API to the post editor `setAttribute` `removeAttribute`