### PR TITLE
Fix sectionParser obliterating text content in certain situations

### DIFF
--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -98,7 +98,7 @@ class SectionParser {
       addSection: (section) => {
         // avoid creating empty paragraphs due to wrapper elements around
         // parser-plugin-handled elements
-        if (this.state.section.isMarkerable && !this.state.text) {
+        if (this.state.section.isMarkerable && !this.state.text && !this.state.section.text) {
           this.state.section = null;
         } else {
           this._closeCurrentSection();


### PR DESCRIPTION
closes https://github.com/bustle/mobiledoc-kit/issues/683

- `addSection` which is called by parser plugins was removing the section rather than closing it when it contains text due to a missing conditional