### PR TITLE
Fix #689: Original range should be remembered after `toggleSection`

### DIFF
--- a/assets/demo/demo.css
+++ b/assets/demo/demo.css
@@ -87,9 +87,6 @@ table tr {
   border: 2px solid #ccc;
 }
 
-.editor {
-}
-
 .two-column {
   display: -webkit-flex;
   display: flex;

--- a/assets/demo/index.html
+++ b/assets/demo/index.html
@@ -58,8 +58,9 @@
         <div class="toolbar">
           <!-- Icons are from https://material.io/tools/icons/ -->
           <div class="toolbar-section">
-            <button data-action='toggleSection' data-args='h1'>Headline</button>
-            <button data-action='toggleSection' data-args='h2'>Subheadline</button>
+            <button data-action='toggleSection' data-args='h1'>H1</button>
+            <button data-action='toggleSection' data-args='h2'>H2</button>
+            <button data-action='toggleSection' data-args='blockquote'>Quote</button>
           </div>
           <div class="toolbar-section">
             <button data-action='toggleMarkup' data-args='strong'>

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -1,6 +1,6 @@
 import Position from '../utils/cursor/position';
 import Range from 'mobiledoc-kit/utils/cursor/range';
-import { forEach, reduce, filter, values, commonItems } from '../utils/array-utils';
+import { detect, forEach, reduce, filter, values, commonItems } from '../utils/array-utils';
 import { DIRECTION } from '../utils/key';
 import LifecycleCallbacks from '../models/lifecycle-callbacks';
 import assert from '../utils/assert';
@@ -814,12 +814,12 @@ class PostEditor {
 
   _determineNextRangeAfterToggleSection(range, sectionTransformations) {
     if (sectionTransformations.length) {
-      let changedHeadSection = sectionTransformations
-        .find(({ from }) => { return from === range.headSection; })
-        .to;
-      let changedTailSection = sectionTransformations
-        .find(({ from }) => { return from === range.tailSection; })
-        .to;
+      let changedHeadSection = detect(sectionTransformations, ({ from }) => {
+        return from === range.headSection;
+      }).to;
+      let changedTailSection = detect(sectionTransformations, ({ from }) => {
+        return from === range.tailSection;
+      }).to;
 
       if (changedHeadSection.isListSection || changedTailSection.isListSection) {
         // We don't know to which ListItem's the original sections point at, so

--- a/tests/unit/editor/post-test.js
+++ b/tests/unit/editor/post-test.js
@@ -815,7 +815,16 @@ test('#toggleSection changes multiple sections to and from tag name', (assert) =
   assert.equal(post.sections.head.tagName, 'p');
   assert.equal(post.sections.tail.tagName, 'p');
 
-  assert.positionIsEqual(mockEditor._renderedRange.head, post.sections.head.headPosition());
+  assert.positionIsEqual(
+    mockEditor._renderedRange.head,
+    post.sections.head.toPosition(2),
+    'Maintains the selection'
+  );
+  assert.positionIsEqual(
+    mockEditor._renderedRange.tail,
+    post.sections.tail.toPosition(2),
+    'Maintains the selection'
+  );
 });
 
 test('#toggleSection skips over non-markerable sections', (assert) => {
@@ -1299,6 +1308,33 @@ test('#toggleSection joins contiguous list items', (assert) => {
   assert.equal(post.sections.head.items.length, 3, '3 items');
   assert.deepEqual(post.sections.head.items.map(i => i.text),
                    ['abc', '123', 'def']);
+});
+
+test('#toggleSection maintains the selection when the sections in the selected range are still there', (assert) => {
+  let post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+    return post([
+      markupSection('p', [marker('abc')])
+    ]);
+  });
+
+  mockEditor = renderBuiltAbstract(post, mockEditor);
+  const range = Range.create(post.sections.head, 1,
+                             post.sections.head, 2);
+
+  postEditor = new PostEditor(mockEditor);
+  postEditor.toggleSection('h1', range);
+  postEditor.complete();
+
+  assert.positionIsEqual(
+    mockEditor._renderedRange.head,
+    post.sections.head.toPosition(1),
+    'Maintains the selection'
+  );
+  assert.positionIsEqual(
+    mockEditor._renderedRange.tail,
+    post.sections.tail.toPosition(2),
+    'Maintains the selection'
+  );
 });
 
 test('#toggleMarkup when cursor is in non-markerable does nothing', (assert) => {


### PR DESCRIPTION
## Changes
### Fix #689
The idea is that when toggling a section, we maintain a list of mappings from the original to the new section. Sometimes, sections are maintained but the tag name is simply modified. This happens for instance when going from a paragraph to a H1. However, sometimes sections are destroyed and a new one is created. For instance, when going from a list to a paragraph.

By looking at the mapping of old section to new section, we can reconstruct the selection after toggling:

![mobiledoc-kit](https://user-images.githubusercontent.com/1374412/61291657-5fde8c00-a7cf-11e9-93c2-652aa04e1b8f.gif)

The only edge case is when toggling to a list. There, the sections in the range have to point to ListItem's rather than ListSections. But at the time of toggling, we only have access to the ListSection, and we don't know which ListItem's the new range should point to.

![mobiledoc-kit](https://user-images.githubusercontent.com/1374412/61291752-ae8c2600-a7cf-11e9-85a0-db9c3b6d7a54.gif)

### Other changes
1. Remove redundant CSS from demo.css
2. Add a button in the demo to toggle a quote

