### PR TITLE
Set default range for 'setAttribute' in PostEditor

### DIFF
--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -812,7 +812,7 @@ class PostEditor {
     this.setRange(nextRange);
   }
 
-  setAttribute(key, value, range) {
+  setAttribute(key, value, range=this._range) {
     range = toRange(range);
     let { post } = this.editor;
     let attribute = `data-md-${key}`;


### PR DESCRIPTION
Otherwise the range must be specified every time this public API is used., i.e. requires something like

`postEditor.setAttribute('text-align', 'center', `postEditor._range);`

instead of

`postEditor.setAttribute('text-align', 'center');`