### PR TITLE
Fix #694: Alignment of a section is removed when pressing "Enter"

### DIFF
--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -941,7 +941,7 @@ class PostEditor {
    */
   _splitListAtItem(list, item) {
     let next = list;
-    let prev = this.builder.createListSection(next.tagName);
+    let prev = this.builder.createListSection(next.tagName, [], next.attributes);
     let mid = this.builder.createListSection(next.tagName);
 
     let addToPrev = true;

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -51,7 +51,7 @@ const MarkupSection = class MarkupSection extends Markerable {
 
   splitAtMarker(marker, offset=0) {
     let [beforeSection, afterSection] = [
-      this.builder.createMarkupSection(this.tagName, []),
+      this.builder.createMarkupSection(this.tagName, [], false, this.attributes),
       this.builder.createMarkupSection()
     ];
 

--- a/tests/acceptance/editor-attributes-test.js
+++ b/tests/acceptance/editor-attributes-test.js
@@ -1,0 +1,58 @@
+import Helpers from '../test-helpers';
+
+const { module, test } = Helpers;
+
+let editor, editorElement;
+
+function renderEditor(...args) {
+  editor = Helpers.mobiledoc.renderInto(editorElement, ...args);
+  editor.selectRange(editor.post.tailPosition());
+  return editor;
+}
+
+module('Acceptance: Editor: Attributes', {
+  beforeEach() {
+    editorElement = $('#editor')[0];
+  },
+  afterEach() {
+    if (editor) { editor.destroy(); }
+  }
+});
+
+test('pressing ENTER at the end of an aligned paragraph maintains the alignment (bug #694)', (assert) => {
+  renderEditor(({post, markupSection, marker}) => {
+    return post([
+      markupSection(
+        'p',
+        [marker('abc')],
+        false,
+        { 'data-md-text-align': 'center' }
+      )
+    ]);
+  });
+
+  Helpers.dom.triggerEnter(editor);
+
+  const firstParagraph = document.querySelector('#editor p:first-of-type');
+  assert.equal(firstParagraph.getAttribute('data-md-text-align'), 'center');
+});
+
+test('toggling the section inside an aligned list maintains the alignment of the list (bug #694)', (assert) => {
+  renderEditor(({post, listSection, listItem, marker}) => {
+    return post([
+      listSection(
+        'ul',
+        [
+          listItem([marker('abc')]),
+          listItem([marker('123')])
+        ],
+        { 'data-md-text-align': 'center' }
+      )
+    ]);
+  });
+
+  editor.run(postEditor => postEditor.toggleSection('h1'));
+
+  const ul = document.querySelector('#editor ul');
+  assert.equal(ul.getAttribute('data-md-text-align'), 'center');
+});


### PR DESCRIPTION
Fixes #694 