### PR TITLE
Fix failing Sauce Labs tests and IE11 compatibility 🐾

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "conventional-changelog-cli": "^1.3.2",
     "jquery": "^3.2.1",
     "jsdoc": "^3.5.4",
-    "saucie": "^3.3.0",
-    "testem": "^2.0.0"
+    "saucie": "^3.3.2",
+    "testem": "^2.17.0"
   },
   "main": "dist/commonjs/mobiledoc-kit/index.js"
 }

--- a/sauce_labs/saucie-connect.js
+++ b/sauce_labs/saucie-connect.js
@@ -10,7 +10,8 @@ var opts = {
   accessKey: process.env.SAUCE_ACCESS_KEY,
   verbose: true,
   logger: console.log,
-  pidfile: pidFile
+  pidfile: pidFile,
+  connectVersion: '4.4.12'
 };
 
 if (process.env.TRAVIS_JOB_NUMBER) {

--- a/src/js/models/_attributable.js
+++ b/src/js/models/_attributable.js
@@ -1,3 +1,5 @@
+import { entries } from '../utils/object-utils';
+
 export const VALID_ATTRIBUTES = [
   'data-md-text-align'
 ];
@@ -20,6 +22,6 @@ export function attributable(ctx) {
   };
   ctx.getAttribute = key => ctx.attributes[key];
   ctx.eachAttribute = cb => {
-    Object.entries(ctx.attributes).forEach(([k,v]) => cb(k,v));
+    entries(ctx.attributes).forEach(([k,v]) => cb(k,v));
   };
 }

--- a/src/js/models/_attributable.js
+++ b/src/js/models/_attributable.js
@@ -1,4 +1,5 @@
 import { entries } from '../utils/object-utils';
+import { contains } from '../utils/array-utils';
 
 export const VALID_ATTRIBUTES = [
   'data-md-text-align'
@@ -12,7 +13,7 @@ export function attributable(ctx) {
   ctx.attributes = {};
 
   ctx.setAttribute = (key, value) => {
-    if (!VALID_ATTRIBUTES.includes(key)) {
+    if (!contains(VALID_ATTRIBUTES, key)) {
       throw new Error(`Invalid attribute "${key}" was passed. Constrain attributes to the spec-compliant whitelist.`);
     }
     ctx.attributes[key] = value;

--- a/src/js/models/list-section.js
+++ b/src/js/models/list-section.js
@@ -1,10 +1,12 @@
-import LinkedList from '../utils/linked-list';
-import { forEach, contains } from '../utils/array-utils';
 import { LIST_SECTION_TYPE } from './types';
 import Section from './_section';
+import { attributable } from './_attributable';
+
+import LinkedList from '../utils/linked-list';
+import { forEach, contains } from '../utils/array-utils';
 import { normalizeTagName } from '../utils/dom-utils';
 import assert from '../utils/assert';
-import { attributable } from './_attributable';
+import { entries } from '../utils/object-utils';
 
 export const VALID_LIST_SECTION_TAGNAMES = [
   'ul', 'ol'
@@ -20,7 +22,7 @@ export default class ListSection extends Section {
     this.isLeafSection = false;
 
     attributable(this);
-    Object.entries(attributes).forEach(([k,v]) => this.setAttribute(k, v));
+    entries(attributes).forEach(([k,v]) => this.setAttribute(k, v));
 
     this.items = new LinkedList({
       adoptItem: i => {

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -1,8 +1,10 @@
 import Markerable from './_markerable';
+import { attributable } from './_attributable';
+import { MARKUP_SECTION_TYPE } from './types';
+
 import { normalizeTagName } from '../utils/dom-utils';
 import { contains } from '../utils/array-utils';
-import { MARKUP_SECTION_TYPE } from './types';
-import { attributable } from './_attributable';
+import { entries } from '../utils/object-utils';
 
 // valid values of `tagName` for a MarkupSection
 export const VALID_MARKUP_SECTION_TAGNAMES = [
@@ -38,7 +40,7 @@ const MarkupSection = class MarkupSection extends Markerable {
     super(MARKUP_SECTION_TYPE, tagName, markers);
 
     attributable(this);
-    Object.entries(attributes).forEach(([k,v]) => this.setAttribute(k, v));
+    entries(attributes).forEach(([k,v]) => this.setAttribute(k, v));
 
     this.isMarkupSection = true;
   }

--- a/src/js/parsers/mobiledoc/0-3-2.js
+++ b/src/js/parsers/mobiledoc/0-3-2.js
@@ -5,9 +5,11 @@ import {
   MOBILEDOC_CARD_SECTION_TYPE,
   MOBILEDOC_MARKUP_MARKER_TYPE,
   MOBILEDOC_ATOM_MARKER_TYPE
-} from 'mobiledoc-kit/renderers/mobiledoc/0-3-2';
-import { kvArrayToObject, filter } from "../../utils/array-utils";
-import assert from 'mobiledoc-kit/utils/assert';
+} from '../../renderers/mobiledoc/0-3-2';
+
+import { kvArrayToObject, filter } from '../../utils/array-utils';
+import assert from '../../utils/assert';
+import { entries } from '../../utils/object-utils';
 
 /*
  * Parses from mobiledoc -> post
@@ -113,7 +115,7 @@ export default class MobiledocParser {
     const section = this.builder.createMarkupSection(tagName);
     post.sections.append(section);
     if (attributesArray) {
-      Object.entries(kvArrayToObject(attributesArray)).forEach(([key, value]) => {
+      entries(kvArrayToObject(attributesArray)).forEach(([key, value]) => {
         section.setAttribute(key, value);
       });
     }
@@ -129,7 +131,7 @@ export default class MobiledocParser {
     const section = this.builder.createListSection(tagName);
     post.sections.append(section);
     if (attributesArray) {
-      Object.entries(kvArrayToObject(attributesArray)).forEach(([key, value]) => {
+      entries(kvArrayToObject(attributesArray)).forEach(([key, value]) => {
         section.setAttribute(key, value);
       });
     }

--- a/src/js/utils/object-utils.js
+++ b/src/js/utils/object-utils.js
@@ -1,0 +1,11 @@
+export function entries(obj) {
+  const ownProps = Object.keys(obj);
+  let i = ownProps.length;
+  const resArray = new Array(i);
+
+  while (i--) {
+    resArray[i] = [ownProps[i], obj[ownProps[i]]];
+  }
+
+  return resArray;
+}

--- a/tests/unit/models/list-section-test.js
+++ b/tests/unit/models/list-section-test.js
@@ -2,7 +2,7 @@ import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
 import TestHelpers from '../../test-helpers';
 import { VALID_ATTRIBUTES, INVALID_ATTRIBUTES } from '../../helpers/sections';
 
-const {module, test} = TestHelpers;
+const { module, test } = TestHelpers;
 
 let builder;
 module('Unit: List Section', {
@@ -14,34 +14,39 @@ module('Unit: List Section', {
   }
 });
 
-for (let attribute of VALID_ATTRIBUTES) {
+VALID_ATTRIBUTES.forEach(attribute => {
   // eslint-disable-next-line no-loop-func
-  test(`a section can have attribute "${attribute.key}" with value "${attribute.value}`, (assert) => {
-    const s1 = builder.createListSection('ol', [], { [attribute.key]: attribute.value });
+  test(`a section can have attribute "${attribute.key}" with value "${attribute.value}`, assert => {
+    const attributes = {};
+    attributes[attribute.key] = attribute.value;
+
+    const s1 = builder.createListSection('ol', [], attributes);
     assert.deepEqual(
       s1.attributes,
-      { [attribute.key]: attribute.value },
+      attributes,
       'Attribute set at instantiation'
     );
   });
-}
-
-for (let attribute of INVALID_ATTRIBUTES) {
-  // eslint-disable-next-line no-loop-func
-  test(`a section throws when invalid attribute "${attribute.key}" is passed to a marker`, (assert) => {
-    assert.throws(() => {
-      builder.createListSection('ul', [], { [attribute.key]: attribute.value });
-    });
-  });
-}
-
-test('cloning a list section creates the same type of list section', (assert) => {
-  let item = builder.createListItem([builder.createMarker('abc')]);
-  let list = builder.createListSection('ol', [item]);
-  let cloned = list.clone();
-
-  assert.equal(list.tagName, cloned.tagName);
-  assert.equal(list.items.length, cloned.items.length);
-  assert.equal(list.items.head.text, cloned.items.head.text);
 });
 
+INVALID_ATTRIBUTES.forEach(attribute => {
+  // eslint-disable-next-line no-loop-func
+  test(`a section throws when invalid attribute "${attribute.key}" is passed to a marker`, assert => {
+    const attributes = {};
+    attributes[attribute.key] = attribute.value;
+
+    assert.throws(() => {
+      builder.createListSection('ul', [], attributes);
+    });
+  });
+
+  test('cloning a list section creates the same type of list section', assert => {
+    let item = builder.createListItem([builder.createMarker('abc')]);
+    let list = builder.createListSection('ol', [item]);
+    let cloned = list.clone();
+
+    assert.equal(list.tagName, cloned.tagName);
+    assert.equal(list.items.length, cloned.items.length);
+    assert.equal(list.items.head.text, cloned.items.head.text);
+  });
+});

--- a/tests/unit/models/markup-section-test.js
+++ b/tests/unit/models/markup-section-test.js
@@ -23,7 +23,7 @@ test('a section can append a marker', (assert) => {
   assert.equal(s1.markers.length, 1);
 });
 
-for (let attribute of VALID_ATTRIBUTES) {
+VALID_ATTRIBUTES.forEach(attribute => {
   // eslint-disable-next-line no-loop-func
   test(`a section can have attribute "${attribute.key}" with value "${attribute.value}`, (assert) => {
     const s1 = builder.createMarkupSection('P', [], false, { [attribute.key]: attribute.value });
@@ -33,16 +33,16 @@ for (let attribute of VALID_ATTRIBUTES) {
       'Attribute set at instantiation'
     );
   });
-}
+});
 
-for (let attribute of INVALID_ATTRIBUTES) {
+INVALID_ATTRIBUTES.forEach(attribute => {
   // eslint-disable-next-line no-loop-func
   test(`a section throws when invalid attribute "${attribute.key}" is passed to a marker`, (assert) => {
     assert.throws(() => {
       builder.createMarkupSection('P', [], false, attribute);
     });
   });
-}
+});
 
 test('#isBlank returns true if the text length is zero for two markers', (assert) => {
   const m1 = builder.createMarker('');

--- a/tests/unit/utils/object-utils-test.js
+++ b/tests/unit/utils/object-utils-test.js
@@ -1,0 +1,13 @@
+import Helpers from '../../test-helpers';
+import { entries } from 'mobiledoc-kit/utils/object-utils';
+
+const { module, test } = Helpers;
+
+module('Unit: Utils: Object Utils');
+
+test('#entries works', assert => {
+  assert.deepEqual(entries({ hello: 'world', goodbye: 'moon' }), [
+    ['hello', 'world'],
+    ['goodbye', 'moon']
+  ]);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1468,6 +1468,26 @@ compress-commons@^1.2.0:
     normalize-path "^2.0.0"
     readable-stream "^2.0.0"
 
+compressible@~2.0.16:
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.17.tgz#6e8c108a16ad58384a977f3a482ca20bff2f38c1"
+  integrity sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==
+  dependencies:
+    mime-db ">= 1.40.0 < 2"
+
+compression@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.4.tgz#95523eff170ca57c29a0ca41e6fe131f41e5bb8f"
+  integrity sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==
+  dependencies:
+    accepts "~1.3.5"
+    bytes "3.0.0"
+    compressible "~2.0.16"
+    debug "2.6.9"
+    on-headers "~1.0.2"
+    safe-buffer "5.1.2"
+    vary "~1.1.2"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -4213,6 +4233,11 @@ micromatch@^3.1.10:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
+"mime-db@>= 1.40.0 < 2":
+  version "1.41.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.41.0.tgz#9110408e1f6aa1b34aef51f2c9df3caddf46b6a0"
+  integrity sha512-B5gxBI+2K431XW8C2rcc/lhppbuji67nf9v39eH8pkWoZDxnAL0PxdpH32KYRScniF8qDHBDlI+ipgg5WrCUYw==
+
 mime-db@~1.38.0:
   version "1.38.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
@@ -4549,6 +4574,11 @@ on-finished@~2.3.0:
   integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
   dependencies:
     ee-first "1.1.1"
+
+on-headers@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
+  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -5380,7 +5410,7 @@ sauce-connect-launcher@^1.2.2:
     lodash "^4.16.6"
     rimraf "^2.5.4"
 
-saucie@^3.3.0:
+saucie@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/saucie/-/saucie-3.3.2.tgz#26994ffeaecfbeeff97ebee4687c180da68f136c"
   integrity sha512-aJOFEcmSeJdy3SejBhbr//roE9PXXGJNb4YV6cmzoh82oyy+x7xAWTDLDUQkTwil3mKvcZ/Mifd6/579/gznMQ==
@@ -5937,15 +5967,16 @@ tempfile@^1.1.1:
     os-tmpdir "^1.0.0"
     uuid "^2.0.1"
 
-testem@^2.0.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/testem/-/testem-2.14.0.tgz#418a9a15843f68381659c6a486abb4ea48d06c29"
-  integrity sha512-tldpNPCzXfibmxOoTMGOfr8ztUiHf9292zSXCu7SitBx9dCK83k7vEoa77qJBS9t3RGCQCRF+GNMUuiFw//Mbw==
+testem@^2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/testem/-/testem-2.17.0.tgz#1cb4a2a90524a088803dfe52fbf197a6fd73c883"
+  integrity sha512-PLkIlT523w5rTJPWwR4TL1EiAEa941ECV7d4pMqsB0YdnH+sCTz0loWMKCUSdhR+VijveAZ6anE/JHehE7KqMQ==
   dependencies:
     backbone "^1.1.2"
     bluebird "^3.4.6"
     charm "^1.0.0"
     commander "^2.6.0"
+    compression "^1.7.4"
     consolidate "^0.15.1"
     execa "^1.0.0"
     express "^4.10.7"


### PR DESCRIPTION
We were seeing errors where Sauce couldn’t connect because saucie hardcodes a version of Sauce Connect that is no longer supported.

This PR resolves that issue by overriding the `connectVersion` option to set a compatible version.

Because several PRs were merged despite the test suite not passing, a few changes that are incompatible with IE11 made their way to `master`. This PR also includes fixes for those incompatibilities, specifically `Object.entries`, `Array.includes` and `for..of` loops that transpiled to code that relies on `Symbol`.