### PR TITLE
Fix demo toolbars

### DIFF
--- a/assets/demo/index.html
+++ b/assets/demo/index.html
@@ -223,10 +223,10 @@
     <div class="column right">
       <div class="editor-wrapper" id='editor-toolbar-wrapper'>
         <div class='toolbar'>
-          <button data-action='toggleSection' data-arg='h1'>H1</button>
-          <button data-action='toggleSection' data-arg='h2'>H2</button>
-          <button data-action='toggleMarkup' data-arg='strong'>strong</button>
-          <button data-action='toggleMarkup' data-arg='em'>em</button>
+          <button data-action='toggleSection' data-args='h1'>H1</button>
+          <button data-action='toggleSection' data-args='h2'>H2</button>
+          <button data-action='toggleMarkup' data-args='strong'>strong</button>
+          <button data-action='toggleMarkup' data-args='em'>em</button>
         </div>
         <div id="editor-toolbar" class="editor"></div>
       </div>
@@ -272,8 +272,8 @@
     <div class='column right'>
       <div class="editor-wrapper" id='editor-card-wrapper'>
         <div class='toolbar'>
-          <button data-action='insertCard' data-arg='kitten'>Insert Kitten Card</button>
-          <button data-action='insertAtom' data-arg='mention'>Insert Mention Atom</button>
+          <button data-action='insertCard' data-args='kitten'>Insert Kitten Card</button>
+          <button data-action='insertAtom' data-args='mention'>Insert Mention Atom</button>
         </div>
         <div id="editor-card" class="editor"></div>
     </div>


### PR DESCRIPTION
The toolbars on the last 2 demos at https://bustle.github.io/mobiledoc-kit/demo/ weren't working.  The name of this data attribute looks to have been changed when the text alignment functionality was added but not updated on these other demos.