### PR TITLE
Omit empty section attribute arrays 🍭

### DIFF
--- a/src/js/renderers/mobiledoc/0-3-2.js
+++ b/src/js/renderers/mobiledoc/0-3-2.js
@@ -69,11 +69,19 @@ const postOpcodeCompiler = {
   },
   openMarkupSection(tagName, attributes) {
     this.markers = [];
-    this.sections.push([MOBILEDOC_MARKUP_SECTION_TYPE, tagName, this.markers, attributes]);
+    if (attributes && attributes.length !== 0) {
+      this.sections.push([MOBILEDOC_MARKUP_SECTION_TYPE, tagName, this.markers, attributes]);
+    } else {
+      this.sections.push([MOBILEDOC_MARKUP_SECTION_TYPE, tagName, this.markers]);
+    }
   },
   openListSection(tagName, attributes) {
     this.items = [];
-    this.sections.push([MOBILEDOC_LIST_SECTION_TYPE, tagName, this.items, attributes]);
+    if (attributes && attributes.length !== 0) {
+      this.sections.push([MOBILEDOC_LIST_SECTION_TYPE, tagName, this.items, attributes]);
+    } else {
+      this.sections.push([MOBILEDOC_LIST_SECTION_TYPE, tagName, this.items]);
+    }
   },
   openListItem() {
     this.markers = [];

--- a/tests/unit/renderers/mobiledoc/0-3-2-test.js
+++ b/tests/unit/renderers/mobiledoc/0-3-2-test.js
@@ -40,7 +40,7 @@ test('renders a post with marker', (assert) => {
     cards: [],
     markups: [['strong']],
     sections: [
-      [1, normalizeTagName('P'), [[0, [0], 1, 'Hi']], []]
+      [1, normalizeTagName('P'), [[0, [0], 1, 'Hi']]]
     ]
   });
 });
@@ -65,8 +65,7 @@ test('renders a post section with markers sharing a markup', (assert) => {
         [
           [0, [0], 0, 'Hi'],
           [0, [], 1, ' Guy']
-        ],
-        []
+        ]
       ]
     ]
   });
@@ -102,8 +101,7 @@ test('renders a post with markers with markers with complex attributes', (assert
           [0, [0], 1, 'Hi'],
           [0, [1], 1, ' Guy'],
           [0, [0], 1, ' other guy']
-        ],
-        []
+        ]
       ]
     ]
   });
@@ -169,8 +167,7 @@ test('renders a post with atom', (assert) => {
         [
           [0, [], 0, 'Hi'],
           [1, [], 0, 0]
-        ],
-        []
+        ]
       ]
     ]
   });
@@ -200,8 +197,7 @@ test('renders a post with atom and markup', (assert) => {
         normalizeTagName('P'),
         [
           [1, [0], 1, 0]
-        ],
-        []
+        ]
       ]
     ]
   });
@@ -235,8 +231,7 @@ test('renders a post with atom inside markup', (assert) => {
           [0, [0], 0, 'Hi '],
           [1, [], 0, 0],
           [0, [], 1, ' Bye']
-        ],
-        []
+        ]
       ]
     ]
   });
@@ -340,8 +335,7 @@ test('renders a post with a list', (assert) => {
         [
           [[0, [], 0, 'first item']],
           [[0, [], 0, 'second item']]
-        ],
-        []
+        ]
       ]
     ]
   });
@@ -361,8 +355,7 @@ test('renders an aside as markup section', (assert) => {
       [
         1,
         'aside',
-        [[0, [], 0, 'abc']],
-        []
+        [[0, [], 0, 'abc']]
       ]
     ]
   });


### PR DESCRIPTION
In the 0.3.2 renderer, omit empty section attribute arrays 🍭

Previously, the renderer was always adding a third attributes array to serialized section arrays. In the majority of cases, these are empty arrays that can be safely omitted, saving file size. Now, like with marker attributes, an array is only emitted if there is at least one custom attribute set.