### PR TITLE
Bug Fix: don't modify tail.section if offset is 0 (aka tail.section is not selected)

### DIFF
--- a/assets/demo/debug.html
+++ b/assets/demo/debug.html
@@ -1,70 +1,81 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>Mobiledoc Kit Debug</title>
-  <script src="../tests/jquery/jquery.js"></script>
-  <script src="../global/mobiledoc-kit.js"></script>
-  <script src="./debug.js"></script>
-  <link rel="stylesheet" href="../css/mobiledoc-kit.css">
-  <link rel="stylesheet" href="./debug.css">
-</head>
-<body>
+  <head>
+    <meta charset="utf-8" />
+    <title>Mobiledoc Kit Debug</title>
+    <script src="../tests/jquery/jquery.js"></script>
+    <script src="../global/mobiledoc-kit.js"></script>
+    <script src="./debug.js"></script>
+    <link rel="stylesheet" href="../css/mobiledoc-kit.css" />
+    <link rel="stylesheet" href="./debug.css" />
+  </head>
+  <body>
+    <h1>Mobiledoc Kit Debug Page</h1>
 
-  <h1>Mobiledoc Kit Debug Page</h1>
+    <div id="toolbar">
+      <button class="toggle" data-action="toggleSection" data-toggle="h1">
+        h1
+      </button>
+      <button class="toggle" data-action="toggleSection" data-toggle="h2">
+        h2
+      </button>
+      <button class="toggle" data-action="toggleSection" data-toggle="ul">
+        ul
+      </button>
+      <button class="toggle" data-action="toggleMarkup" data-toggle="strong">
+        strong
+      </button>
+      <button class="toggle" data-action="toggleMarkup" data-toggle="em">
+        em
+      </button>
+      <button class="insert-atom" data-name="mention">@mention</button>
+      <button class="insert-atom" data-name="click">@click</button>
+      <button class="insert-card" data-name="movable">movable card</button>
+      <button
+        class="toggle-method"
+        data-on="disableEditing"
+        data-off="enableEditing"
+      >
+        toggle editable
+      </button>
+    </div>
 
-  <div id='toolbar'>
-    <button class='toggle' data-action='toggleSection' data-toggle='h1'>h1</button>
-    <button class='toggle' data-action='toggleSection' data-toggle='h2'>h2</button>
-    <button class='toggle' data-action='toggleMarkup' data-toggle='strong'>strong</button>
-    <button class='toggle' data-action='toggleMarkup' data-toggle='em'>em</button>
-    <button class='insert-atom' data-name='mention'>@mention</button>
-    <button class='insert-atom' data-name='click'>@click</button>
-    <button class='insert-card' data-name='movable'>movable card</button>
-    <button class='toggle-method' data-on='disableEditing' data-off='enableEditing'>
-      toggle editable
-    </button>
-  </div>
-
-  <div id="editor"></div>
-
-  <div>
-    <h2>Editor Info</h2>
+    <div id="editor"></div>
 
     <div>
-      <h3>Cursor</h3>
-      <div id='cursor'>
+      <h2>Editor Info</h2>
+
+      <div>
+        <h3>Cursor</h3>
+        <div id="cursor"></div>
+      </div>
+
+      <div>
+        <h3>Post</h3>
+        <div id="post"></div>
+      </div>
+
+      <div>
+        <h3>Input Mode</h3>
+        <div id="input-mode"></div>
+      </div>
+
+      <div>
+        <h3>Error</h3>
+        <div id="error">
+          <span class="name"></span>
+          <span class="message"></span>
+        </div>
       </div>
     </div>
 
     <div>
-      <h3>Post</h3>
-      <div id='post'>
+      <h2>Browser Info</h2>
+
+      <div>
+        <h3>Selection</h3>
+        <div id="selection"></div>
       </div>
     </div>
-
-    <div>
-      <h3>Input Mode</h3>
-      <div id='input-mode'>
-      </div>
-    </div>
-
-    <div>
-      <h3>Error</h3>
-      <div id='error'>
-        <span class='name'></span>
-        <span class='message'></span>
-      </div>
-    </div>
-  </div>
-
-  <div>
-    <h2>Browser Info</h2>
-
-    <div>
-      <h3>Selection</h3>
-      <div id="selection"></div>
-    </div>
-  </div>
-</body>
+  </body>
 </html>

--- a/assets/demo/debug.html
+++ b/assets/demo/debug.html
@@ -1,81 +1,70 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <title>Mobiledoc Kit Debug</title>
-    <script src="../tests/jquery/jquery.js"></script>
-    <script src="../global/mobiledoc-kit.js"></script>
-    <script src="./debug.js"></script>
-    <link rel="stylesheet" href="../css/mobiledoc-kit.css" />
-    <link rel="stylesheet" href="./debug.css" />
-  </head>
-  <body>
-    <h1>Mobiledoc Kit Debug Page</h1>
+<head>
+  <meta charset="utf-8">
+  <title>Mobiledoc Kit Debug</title>
+  <script src="../tests/jquery/jquery.js"></script>
+  <script src="../global/mobiledoc-kit.js"></script>
+  <script src="./debug.js"></script>
+  <link rel="stylesheet" href="../css/mobiledoc-kit.css">
+  <link rel="stylesheet" href="./debug.css">
+</head>
+<body>
 
-    <div id="toolbar">
-      <button class="toggle" data-action="toggleSection" data-toggle="h1">
-        h1
-      </button>
-      <button class="toggle" data-action="toggleSection" data-toggle="h2">
-        h2
-      </button>
-      <button class="toggle" data-action="toggleSection" data-toggle="ul">
-        ul
-      </button>
-      <button class="toggle" data-action="toggleMarkup" data-toggle="strong">
-        strong
-      </button>
-      <button class="toggle" data-action="toggleMarkup" data-toggle="em">
-        em
-      </button>
-      <button class="insert-atom" data-name="mention">@mention</button>
-      <button class="insert-atom" data-name="click">@click</button>
-      <button class="insert-card" data-name="movable">movable card</button>
-      <button
-        class="toggle-method"
-        data-on="disableEditing"
-        data-off="enableEditing"
-      >
-        toggle editable
-      </button>
-    </div>
+  <h1>Mobiledoc Kit Debug Page</h1>
 
-    <div id="editor"></div>
+  <div id='toolbar'>
+    <button class='toggle' data-action='toggleSection' data-toggle='h1'>h1</button>
+    <button class='toggle' data-action='toggleSection' data-toggle='h2'>h2</button>
+    <button class='toggle' data-action='toggleMarkup' data-toggle='strong'>strong</button>
+    <button class='toggle' data-action='toggleMarkup' data-toggle='em'>em</button>
+    <button class='insert-atom' data-name='mention'>@mention</button>
+    <button class='insert-atom' data-name='click'>@click</button>
+    <button class='insert-card' data-name='movable'>movable card</button>
+    <button class='toggle-method' data-on='disableEditing' data-off='enableEditing'>
+      toggle editable
+    </button>
+  </div>
+
+  <div id="editor"></div>
+
+  <div>
+    <h2>Editor Info</h2>
 
     <div>
-      <h2>Editor Info</h2>
-
-      <div>
-        <h3>Cursor</h3>
-        <div id="cursor"></div>
-      </div>
-
-      <div>
-        <h3>Post</h3>
-        <div id="post"></div>
-      </div>
-
-      <div>
-        <h3>Input Mode</h3>
-        <div id="input-mode"></div>
-      </div>
-
-      <div>
-        <h3>Error</h3>
-        <div id="error">
-          <span class="name"></span>
-          <span class="message"></span>
-        </div>
+      <h3>Cursor</h3>
+      <div id='cursor'>
       </div>
     </div>
 
     <div>
-      <h2>Browser Info</h2>
-
-      <div>
-        <h3>Selection</h3>
-        <div id="selection"></div>
+      <h3>Post</h3>
+      <div id='post'>
       </div>
     </div>
-  </body>
+
+    <div>
+      <h3>Input Mode</h3>
+      <div id='input-mode'>
+      </div>
+    </div>
+
+    <div>
+      <h3>Error</h3>
+      <div id='error'>
+        <span class='name'></span>
+        <span class='message'></span>
+      </div>
+    </div>
+  </div>
+
+  <div>
+    <h2>Browser Info</h2>
+
+    <div>
+      <h3>Selection</h3>
+      <div id="selection"></div>
+    </div>
+  </div>
+</body>
 </html>

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -844,7 +844,9 @@ class PostEditor {
    */
   toggleSection(sectionTagName, range = this._range) {
     range = toRange(range);
-    const { tail } = range;
+    const { head, tail } = range;
+    const togglingList = sectionTagName === "ul";
+    const tailNotSelected = tail.offset === 0 && head.section !== tail.section;
 
     sectionTagName = normalizeTagName(sectionTagName);
     let { post } = this.editor;
@@ -852,7 +854,7 @@ class PostEditor {
     let everySectionHasTagName = true;
     post.walkMarkerableSections(range, section => {
       // only care about tail section tag if tail section is selected
-      if (tail.offset === 0 && tail.section === section) {
+      if (!togglingList && tailNotSelected && tail.section === section) {
         return;
       }
 
@@ -867,7 +869,7 @@ class PostEditor {
       let changedSection;
 
       // tail section not selected, no transform needed
-      if (tail.offset === 0 && tail.section === section) {
+      if (!togglingList && tailNotSelected && tail.section === section) {
         changedSection = section;
       } else {
         changedSection = this.changeSectionTagName(section, tagName);

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -1,9 +1,9 @@
-import { POST_TYPE } from './types';
-import LinkedList from 'mobiledoc-kit/utils/linked-list';
-import { forEach } from 'mobiledoc-kit/utils/array-utils';
-import Set from 'mobiledoc-kit/utils/set';
-import Position from 'mobiledoc-kit/utils/cursor/position';
-import assert from 'mobiledoc-kit/utils/assert';
+import { POST_TYPE } from "./types";
+import LinkedList from "mobiledoc-kit/utils/linked-list";
+import { forEach } from "mobiledoc-kit/utils/array-utils";
+import Set from "mobiledoc-kit/utils/set";
+import Position from "mobiledoc-kit/utils/cursor/position";
+import assert from "mobiledoc-kit/utils/assert";
 
 /**
  * The Post is an in-memory representation of an editor's document.
@@ -20,8 +20,8 @@ class Post {
   constructor() {
     this.type = POST_TYPE;
     this.sections = new LinkedList({
-      adoptItem: s => s.post = s.parent = this,
-      freeItem: s => s.post = s.parent = null
+      adoptItem: s => (s.post = s.parent = this),
+      freeItem: s => (s.post = s.parent = null)
     });
   }
 
@@ -70,8 +70,10 @@ class Post {
    * @public
    */
   get hasContent() {
-    if ((this.sections.length > 1) ||
-        (this.sections.length === 1 && !this.sections.head.isBlank)) {
+    if (
+      this.sections.length > 1 ||
+      (this.sections.length === 1 && !this.sections.head.isBlank)
+    ) {
       return true;
     } else {
       return false;
@@ -86,10 +88,11 @@ class Post {
     const markers = [];
 
     this.walkMarkerableSections(range, section => {
-      section._markersInRange(
-        range.trimTo(section),
-        (m, {isContained}) => { if (isContained) { markers.push(m); } }
-      );
+      section._markersInRange(range.trimTo(section), (m, { isContained }) => {
+        if (isContained) {
+          markers.push(m);
+        }
+      });
     });
 
     return markers;
@@ -105,12 +108,12 @@ class Post {
         if (back && forward && back === forward) {
           back.markups.forEach(m => markups.add(m));
         } else {
-          (back && back.markups || []).forEach(m => {
+          ((back && back.markups) || []).forEach(m => {
             if (m.isForwardInclusive()) {
               markups.add(m);
             }
           });
-          (forward && forward.markups || []).forEach(m => {
+          ((forward && forward.markups) || []).forEach(m => {
             if (m.isBackwardInclusive()) {
               markups.add(m);
             }
@@ -118,10 +121,9 @@ class Post {
         }
       }
     } else {
-      this.walkMarkerableSections(range, (section) => {
-        forEach(
-          section.markupsInRange(range.trimTo(section)),
-          m => markups.add(m)
+      this.walkMarkerableSections(range, section => {
+        forEach(section.markupsInRange(range.trimTo(section)), m =>
+          markups.add(m)
         );
       });
     }
@@ -167,7 +169,9 @@ class Post {
   // return the next section that has markers after this one,
   // possibly skipping non-markerable sections
   _nextLeafSection(section) {
-    if (!section) { return null; }
+    if (!section) {
+      return null;
+    }
 
     const next = section.next;
     if (next) {
@@ -176,7 +180,7 @@ class Post {
       } else if (next.items) {
         return next.items.head;
       } else {
-        assert('Cannot determine next section from non-leaf-section', false);
+        assert("Cannot determine next section from non-leaf-section", false);
       }
     } else if (section.isNested) {
       // if there is no section after this, but this section is a child
@@ -193,9 +197,10 @@ class Post {
   trimTo(range) {
     const post = this.builder.createPost();
     const { builder } = this;
+    const { tail } = range;
 
     let sectionParent = post,
-        listParent = null;
+      listParent = null;
     this.walkLeafSections(range, section => {
       let newSection;
       if (section.isMarkerable) {
@@ -212,16 +217,26 @@ class Post {
         } else {
           listParent = null;
           sectionParent = post;
-          newSection = builder.createMarkupSection(section.tagName);
+          const tagName =
+            tail.offset === 0 && tail.section === section
+              ? "p"
+              : section.tagName;
+          newSection = builder.createMarkupSection(tagName);
         }
 
         let currentRange = range.trimTo(section);
         forEach(
-          section.markersFor(currentRange.headSectionOffset, currentRange.tailSectionOffset),
+          section.markersFor(
+            currentRange.headSectionOffset,
+            currentRange.tailSectionOffset
+          ),
           m => newSection.markers.append(m)
         );
       } else {
-        newSection = section.clone();
+        newSection =
+          tail.offset === 0 && tail.section === section
+            ? builder.createMarkupSection("p")
+            : section.clone();
         sectionParent = post;
       }
       if (sectionParent) {

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -197,7 +197,8 @@ class Post {
   trimTo(range) {
     const post = this.builder.createPost();
     const { builder } = this;
-    const { tail } = range;
+    const { head, tail } = range;
+    const tailNotSelected = tail.offset === 0 && head.section !== tail.section;
 
     let sectionParent = post,
       listParent = null;
@@ -218,9 +219,7 @@ class Post {
           listParent = null;
           sectionParent = post;
           const tagName =
-            tail.offset === 0 && tail.section === section
-              ? "p"
-              : section.tagName;
+            tailNotSelected && tail.section === section ? "p" : section.tagName;
           newSection = builder.createMarkupSection(tagName);
         }
 
@@ -234,7 +233,7 @@ class Post {
         );
       } else {
         newSection =
-          tail.offset === 0 && tail.section === section
+          tailNotSelected && tail.section === section
             ? builder.createMarkupSection("p")
             : section.clone();
         sectionParent = post;

--- a/tests/unit/editor/post-test.js
+++ b/tests/unit/editor/post-test.js
@@ -1,8 +1,8 @@
-import PostEditor from 'mobiledoc-kit/editor/post';
-import { Editor } from 'mobiledoc-kit';
-import Helpers from '../../test-helpers';
-import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
-import Range from 'mobiledoc-kit/utils/cursor/range';
+import PostEditor from "mobiledoc-kit/editor/post";
+import { Editor } from "mobiledoc-kit";
+import Helpers from "../../test-helpers";
+import PostNodeBuilder from "mobiledoc-kit/models/post-node-builder";
+import Range from "mobiledoc-kit/utils/cursor/range";
 
 const { module, test } = Helpers;
 
@@ -10,13 +10,20 @@ let editor, editorElement;
 
 let builder, postEditor, mockEditor;
 
-let { postEditor: { MockEditor, renderBuiltAbstract } } = Helpers;
+let {
+  postEditor: { MockEditor, renderBuiltAbstract }
+} = Helpers;
 
-function buildEditorWithMobiledoc(builderFn, autofocus=true) {
+function buildEditorWithMobiledoc(builderFn, autofocus = true) {
   let mobiledoc = Helpers.mobiledoc.build(builderFn);
   let unknownCardHandler = () => {};
   let unknownAtomHandler = () => {};
-  editor = new Editor({mobiledoc, unknownCardHandler, unknownAtomHandler, autofocus});
+  editor = new Editor({
+    mobiledoc,
+    unknownCardHandler,
+    unknownAtomHandler,
+    autofocus
+  });
   editor.render(editorElement);
   let selectRange = editor.selectRange;
   editor.selectRange = function(range) {
@@ -27,9 +34,9 @@ function buildEditorWithMobiledoc(builderFn, autofocus=true) {
   return editor;
 }
 
-module('Unit: PostEditor', {
+module("Unit: PostEditor", {
   beforeEach() {
-    editorElement = $('#editor')[0];
+    editorElement = $("#editor")[0];
     builder = new PostNodeBuilder();
     mockEditor = new MockEditor(builder);
     postEditor = new PostEditor(mockEditor);
@@ -43,13 +50,11 @@ module('Unit: PostEditor', {
   }
 });
 
-test('#splitMarkers when headMarker = tailMarker', (assert) => {
+test("#splitMarkers when headMarker = tailMarker", assert => {
   let post, section;
-  Helpers.postAbstract.build(({marker, markupSection, post: buildPost}) => {
-    section = markupSection('p', [
-      marker('abcd')
-    ]);
-    post = buildPost([ section ]);
+  Helpers.postAbstract.build(({ marker, markupSection, post: buildPost }) => {
+    section = markupSection("p", [marker("abcd")]);
+    post = buildPost([section]);
   });
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
@@ -59,15 +64,13 @@ test('#splitMarkers when headMarker = tailMarker', (assert) => {
   const markers = postEditor.splitMarkers(range);
   postEditor.complete();
 
-  assert.equal(markers.length, 1, 'markers');
-  assert.equal(markers[0].value, 'bc', 'marker 0');
+  assert.equal(markers.length, 1, "markers");
+  assert.equal(markers[0].value, "bc", "marker 0");
 });
 
-test('#splitMarkers when head section = tail section, but different markers', (assert) => {
-  const post = Helpers.postAbstract.build(({marker, markupSection, post}) =>
-    post([
-      markupSection('p', [marker('abc'), marker('def')])
-    ])
+test("#splitMarkers when head section = tail section, but different markers", assert => {
+  const post = Helpers.postAbstract.build(({ marker, markupSection, post }) =>
+    post([markupSection("p", [marker("abc"), marker("def")])])
   );
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
@@ -78,21 +81,17 @@ test('#splitMarkers when head section = tail section, but different markers', (a
   const markers = postEditor.splitMarkers(range);
   postEditor.complete();
 
-  assert.equal(markers.length, 2, 'markers');
-  assert.equal(markers[0].value, 'c', 'marker 0');
-  assert.equal(markers[1].value, 'de', 'marker 1');
+  assert.equal(markers.length, 2, "markers");
+  assert.equal(markers[0].value, "c", "marker 0");
+  assert.equal(markers[1].value, "de", "marker 1");
 });
 
 // see https://github.com/bustle/mobiledoc-kit/issues/121
-test('#splitMarkers when single-character marker at start', (assert) => {
+test("#splitMarkers when single-character marker at start", assert => {
   let post, section;
-  Helpers.postAbstract.build(({marker, markupSection, post: buildPost}) => {
-    section = markupSection('p', [
-      marker('a'),
-      marker('b'),
-      marker('c')
-    ]);
-    post = buildPost([ section ]);
+  Helpers.postAbstract.build(({ marker, markupSection, post: buildPost }) => {
+    section = markupSection("p", [marker("a"), marker("b"), marker("c")]);
+    post = buildPost([section]);
   });
 
   renderBuiltAbstract(post, mockEditor);
@@ -101,65 +100,71 @@ test('#splitMarkers when single-character marker at start', (assert) => {
   const markers = postEditor.splitMarkers(range);
   postEditor.complete();
 
-  assert.equal(markers.length, 2, 'markers');
-  assert.equal(markers[0].value, 'b', 'marker 0');
-  assert.equal(markers[1].value, 'c', 'marker 1');
+  assert.equal(markers.length, 2, "markers");
+  assert.equal(markers[0].value, "b", "marker 0");
+  assert.equal(markers[1].value, "c", "marker 1");
 });
 
-test('#replaceSection one markup section with another', (assert) => {
+test("#replaceSection one markup section with another", assert => {
   let _section1, _section2;
-  const post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
-    _section1 = markupSection('p', [marker('abc')]);
-    _section2 = markupSection('p', [marker('123')]);
+  const post = Helpers.postAbstract.build(({ post, markupSection, marker }) => {
+    _section1 = markupSection("p", [marker("abc")]);
+    _section2 = markupSection("p", [marker("123")]);
     return post([_section1]);
   });
   renderBuiltAbstract(post, mockEditor);
 
-  assert.equal(post.sections.head.text, 'abc', 'precond - section text');
-  assert.equal(post.sections.length, 1, 'precond - only 1 section');
+  assert.equal(post.sections.head.text, "abc", "precond - section text");
+  assert.equal(post.sections.length, 1, "precond - only 1 section");
   postEditor.replaceSection(_section1, _section2);
   postEditor.complete();
 
-  assert.equal(post.sections.head.text, '123', 'section replaced');
-  assert.equal(post.sections.length, 1, 'only 1 section');
+  assert.equal(post.sections.head.text, "123", "section replaced");
+  assert.equal(post.sections.length, 1, "only 1 section");
 });
 
-test('#replaceSection markup section with list section', (assert) => {
+test("#replaceSection markup section with list section", assert => {
   let _section1, _section2;
   const post = Helpers.postAbstract.build(
-    ({post, markupSection, listSection, listItem, marker}) => {
-    _section1 = markupSection('p', [marker('abc')]);
-    _section2 = listSection('ul', [listItem([marker('123')])]);
-    return post([_section1]);
-  });
+    ({ post, markupSection, listSection, listItem, marker }) => {
+      _section1 = markupSection("p", [marker("abc")]);
+      _section2 = listSection("ul", [listItem([marker("123")])]);
+      return post([_section1]);
+    }
+  );
   renderBuiltAbstract(post, mockEditor);
 
-  assert.equal(post.sections.head.text, 'abc', 'precond - section text');
-  assert.equal(post.sections.length, 1, 'precond - only 1 section');
+  assert.equal(post.sections.head.text, "abc", "precond - section text");
+  assert.equal(post.sections.length, 1, "precond - only 1 section");
   postEditor.replaceSection(_section1, _section2);
   postEditor.complete();
 
-  assert.equal(post.sections.head.items.head.text, '123', 'section replaced');
-  assert.equal(post.sections.length, 1, 'only 1 section');
+  assert.equal(post.sections.head.items.head.text, "123", "section replaced");
+  assert.equal(post.sections.length, 1, "only 1 section");
 });
 
-test('#replaceSection solo list item with markup section removes list section', (assert) => {
+test("#replaceSection solo list item with markup section removes list section", assert => {
   let _section1, _section2;
   const post = Helpers.postAbstract.build(
-    ({post, markupSection, listSection, listItem, marker}) => {
-    _section1 = listItem([marker('abc')]);
-    _section2 = markupSection('p', [marker('123')]);
-    return post([listSection('ul', [_section1])]);
-  });
+    ({ post, markupSection, listSection, listItem, marker }) => {
+      _section1 = listItem([marker("abc")]);
+      _section2 = markupSection("p", [marker("123")]);
+      return post([listSection("ul", [_section1])]);
+    }
+  );
   renderBuiltAbstract(post, mockEditor);
 
-  assert.equal(post.sections.head.items.head.text, 'abc', 'precond - list item text');
-  assert.equal(post.sections.length, 1, 'precond - only 1 section');
+  assert.equal(
+    post.sections.head.items.head.text,
+    "abc",
+    "precond - list item text"
+  );
+  assert.equal(post.sections.length, 1, "precond - only 1 section");
   postEditor.replaceSection(_section1, _section2);
   postEditor.complete();
 
-  assert.equal(post.sections.head.text, '123', 'section replaced');
-  assert.equal(post.sections.length, 1, 'only 1 section');
+  assert.equal(post.sections.head.text, "123", "section replaced");
+  assert.equal(post.sections.length, 1, "only 1 section");
 });
 
 /*
@@ -194,70 +199,83 @@ test('#replaceSection middle list item with markup section cuts list into two', 
 
 */
 
-test('#replaceSection last list item with markup section when multiple list items appends after list section', (assert) => {
+test("#replaceSection last list item with markup section when multiple list items appends after list section", assert => {
   let _section1, _section2;
   const post = Helpers.postAbstract.build(
-    ({post, markupSection, listSection, listItem, marker}) => {
-    _section1 = listItem([marker('abc')]);
-    _section2 = markupSection('p', [marker('123')]);
-    return post([listSection('ul', [
-      listItem([marker('before li')]),
-      _section1
-    ])]);
-  });
+    ({ post, markupSection, listSection, listItem, marker }) => {
+      _section1 = listItem([marker("abc")]);
+      _section2 = markupSection("p", [marker("123")]);
+      return post([
+        listSection("ul", [listItem([marker("before li")]), _section1])
+      ]);
+    }
+  );
   renderBuiltAbstract(post, mockEditor);
 
-  assert.equal(post.sections.head.items.length, 2, 'precond - 2 lis');
-  assert.equal(post.sections.head.items.tail.text, 'abc', 'precond - list item text');
-  assert.equal(post.sections.length, 1, 'precond - only 1 section');
+  assert.equal(post.sections.head.items.length, 2, "precond - 2 lis");
+  assert.equal(
+    post.sections.head.items.tail.text,
+    "abc",
+    "precond - list item text"
+  );
+  assert.equal(post.sections.length, 1, "precond - only 1 section");
   postEditor.replaceSection(_section1, _section2);
   postEditor.complete();
 
-  assert.equal(post.sections.head.items.length, 1, 'only 1 li');
-  assert.equal(post.sections.head.items.head.text, 'before li', 'first li remains');
-  assert.equal(post.sections.length, 2, '2 sections');
-  assert.equal(post.sections.tail.text, '123', 'new section text is there');
+  assert.equal(post.sections.head.items.length, 1, "only 1 li");
+  assert.equal(
+    post.sections.head.items.head.text,
+    "before li",
+    "first li remains"
+  );
+  assert.equal(post.sections.length, 2, "2 sections");
+  assert.equal(post.sections.tail.text, "123", "new section text is there");
 });
 
-test('#replaceSection when section is null appends new section', (assert) => {
+test("#replaceSection when section is null appends new section", assert => {
   let newEmptySection;
-  const post = Helpers.postAbstract.build(
-    ({post, markupSection}) => {
-    newEmptySection = markupSection('p');
+  const post = Helpers.postAbstract.build(({ post, markupSection }) => {
+    newEmptySection = markupSection("p");
     return post();
   });
   renderBuiltAbstract(post, mockEditor);
 
-  assert.equal(post.sections.length, 0, 'precond - no sections');
+  assert.equal(post.sections.length, 0, "precond - no sections");
   postEditor.replaceSection(null, newEmptySection);
   postEditor.complete();
 
-  assert.equal(post.sections.length, 1, 'has 1 section');
-  assert.equal(post.sections.head.text, '', 'no text in new section');
+  assert.equal(post.sections.length, 1, "has 1 section");
+  assert.equal(post.sections.head.text, "", "no text in new section");
 });
 
-test('#insertSectionAtEnd inserts the section at the end of the mobiledoc', (assert) => {
+test("#insertSectionAtEnd inserts the section at the end of the mobiledoc", assert => {
   let newSection;
-  const post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
-    newSection = markupSection('p', [marker('123')]);
-    return post([markupSection('p', [marker('abc')])]);
+  const post = Helpers.postAbstract.build(({ post, markupSection, marker }) => {
+    newSection = markupSection("p", [marker("123")]);
+    return post([markupSection("p", [marker("abc")])]);
   });
   renderBuiltAbstract(post, mockEditor);
 
   postEditor.insertSectionAtEnd(newSection);
   postEditor.complete();
 
-  assert.equal(post.sections.length, 2, 'new section added');
-  assert.equal(post.sections.tail.text, '123', 'new section added at end');
+  assert.equal(post.sections.length, 2, "new section added");
+  assert.equal(post.sections.tail.text, "123", "new section added at end");
 });
 
-test('markers with identical non-attribute markups get coalesced after applying or removing markup', (assert) => {
+test("markers with identical non-attribute markups get coalesced after applying or removing markup", assert => {
   let strong, section;
-  const post = Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
-    strong = markup('strong');
-    section = markupSection('p', [marker('a'), marker('b',[strong]), marker('c')]);
-    return post([section]);
-  });
+  const post = Helpers.postAbstract.build(
+    ({ post, markupSection, marker, markup }) => {
+      strong = markup("strong");
+      section = markupSection("p", [
+        marker("a"),
+        marker("b", [strong]),
+        marker("c")
+      ]);
+      return post([section]);
+    }
+  );
   renderBuiltAbstract(post, mockEditor);
 
   // removing the strong from the "b"
@@ -266,30 +284,39 @@ test('markers with identical non-attribute markups get coalesced after applying 
   postEditor.removeMarkupFromRange(range, strong);
   postEditor.complete();
 
-  assert.equal(section.markers.length, 1, 'similar markers are coalesced');
-  assert.equal(section.markers.head.value, 'abc', 'marker value is correct');
-  assert.ok(!section.markers.head.hasMarkup(strong), 'marker has no bold');
+  assert.equal(section.markers.length, 1, "similar markers are coalesced");
+  assert.equal(section.markers.head.value, "abc", "marker value is correct");
+  assert.ok(!section.markers.head.hasMarkup(strong), "marker has no bold");
 
   // adding strong to each of the characters individually
   postEditor = new PostEditor(mockEditor);
-  for (let i=0; i < section.length; i++) {
-    range = Range.create(section, i, section, i+1);
+  for (let i = 0; i < section.length; i++) {
+    range = Range.create(section, i, section, i + 1);
     postEditor.addMarkupToRange(range, strong);
   }
   postEditor.complete();
 
-  assert.equal(section.markers.length, 1, 'bold markers coalesced');
-  assert.equal(section.markers.head.value, 'abc', 'bold marker value is correct');
-  assert.ok(section.markers.head.hasMarkup(strong), 'bold marker has bold');
+  assert.equal(section.markers.length, 1, "bold markers coalesced");
+  assert.equal(
+    section.markers.head.value,
+    "abc",
+    "bold marker value is correct"
+  );
+  assert.ok(section.markers.head.hasMarkup(strong), "bold marker has bold");
 });
 
-test('markers do not get coalesced with atoms', (assert) => {
+test("markers do not get coalesced with atoms", assert => {
   let strong, section;
-  let post = Helpers.postAbstract.build(({post, markupSection, marker, atom, markup}) => {
-    strong = markup('strong');
-    section = markupSection('p', [atom('the-atom', 'A'), marker('b',[strong])]);
-    return post([section]);
-  });
+  let post = Helpers.postAbstract.build(
+    ({ post, markupSection, marker, atom, markup }) => {
+      strong = markup("strong");
+      section = markupSection("p", [
+        atom("the-atom", "A"),
+        marker("b", [strong])
+      ]);
+      return post([section]);
+    }
+  );
   renderBuiltAbstract(post, mockEditor);
 
   // removing the strong from the "b"
@@ -298,26 +325,28 @@ test('markers do not get coalesced with atoms', (assert) => {
   postEditor.removeMarkupFromRange(range, strong);
   postEditor.complete();
 
-  assert.equal(section.markers.length, 2, 'still 2 markers');
-  assert.equal(section.markers.head.value, 'A', 'head marker value is correct');
-  assert.ok(section.markers.head.isAtom, 'head marker is atom');
-  assert.equal(section.markers.tail.value, 'b', 'tail marker value is correct');
-  assert.ok(section.markers.tail.isMarker, 'tail marker is marker');
+  assert.equal(section.markers.length, 2, "still 2 markers");
+  assert.equal(section.markers.head.value, "A", "head marker value is correct");
+  assert.ok(section.markers.head.isAtom, "head marker is atom");
+  assert.equal(section.markers.tail.value, "b", "tail marker value is correct");
+  assert.ok(section.markers.tail.isMarker, "tail marker is marker");
 
-  assert.ok(!section.markers.head.hasMarkup(strong), 'head marker has no bold');
-  assert.ok(!section.markers.tail.hasMarkup(strong), 'tail marker has no bold');
+  assert.ok(!section.markers.head.hasMarkup(strong), "head marker has no bold");
+  assert.ok(!section.markers.tail.hasMarkup(strong), "tail marker has no bold");
 });
 
-test('neighboring atoms do not get coalesced', (assert) => {
+test("neighboring atoms do not get coalesced", assert => {
   let strong, section;
-  let post = Helpers.postAbstract.build(({post, markupSection, marker, atom, markup}) => {
-    strong = markup('strong');
-    section = markupSection('p', [
-      atom('the-atom', 'A', {}, [strong]),
-      atom('the-atom', 'A', {}, [strong])
-    ]);
-    return post([section]);
-  });
+  let post = Helpers.postAbstract.build(
+    ({ post, markupSection, marker, atom, markup }) => {
+      strong = markup("strong");
+      section = markupSection("p", [
+        atom("the-atom", "A", {}, [strong]),
+        atom("the-atom", "A", {}, [strong])
+      ]);
+      return post([section]);
+    }
+  );
   renderBuiltAbstract(post, mockEditor);
 
   let range = Range.create(section, 0, section, 2);
@@ -325,74 +354,70 @@ test('neighboring atoms do not get coalesced', (assert) => {
   postEditor.removeMarkupFromRange(range, strong);
   postEditor.complete();
 
-  assert.equal(section.markers.length, 2, 'atoms not coalesced');
+  assert.equal(section.markers.length, 2, "atoms not coalesced");
   assert.ok(!section.markers.head.hasMarkup(strong));
   assert.ok(!section.markers.tail.hasMarkup(strong));
 });
 
-test('#removeMarkupFromRange is no-op with collapsed range', (assert) => {
+test("#removeMarkupFromRange is no-op with collapsed range", assert => {
   let section, markup;
-  const post = Helpers.postAbstract.build(({
-    post, markupSection, marker, markup: buildMarkup
-  }) => {
-    markup = buildMarkup('strong');
-    section = markupSection('p', [
-      marker('abc')
-    ]);
-    return post([section]);
-  });
+  const post = Helpers.postAbstract.build(
+    ({ post, markupSection, marker, markup: buildMarkup }) => {
+      markup = buildMarkup("strong");
+      section = markupSection("p", [marker("abc")]);
+      return post([section]);
+    }
+  );
   renderBuiltAbstract(post, mockEditor);
 
   let range = Range.create(section, 1, section, 1);
   postEditor.removeMarkupFromRange(range, markup);
   postEditor.complete();
 
-  assert.equal(section.markers.length, 1, 'similar markers are coalesced');
-  assert.equal(section.markers.head.value, 'abc', 'marker value is correct');
-  assert.ok(!section.markers.head.hasMarkup(markup), 'marker has no markup');
+  assert.equal(section.markers.length, 1, "similar markers are coalesced");
+  assert.equal(section.markers.head.value, "abc", "marker value is correct");
+  assert.ok(!section.markers.head.hasMarkup(markup), "marker has no markup");
 });
 
-test('#removeMarkupFromRange splits markers when necessary', (assert) => {
+test("#removeMarkupFromRange splits markers when necessary", assert => {
   let bold, section;
   let post = Helpers.postAbstract.build(
-    ({post, marker, markup, markupSection}) => {
-    bold = markup('b');
-    section = markupSection('p', [
-      marker('abc', [bold]),
-      marker('def')
-    ]);
-    return post([section]);
-  });
+    ({ post, marker, markup, markupSection }) => {
+      bold = markup("b");
+      section = markupSection("p", [marker("abc", [bold]), marker("def")]);
+      return post([section]);
+    }
+  );
 
   renderBuiltAbstract(post, mockEditor);
 
-  let range = Range.create(section, 'a'.length,
-                           section, 'abcd'.length);
+  let range = Range.create(section, "a".length, section, "abcd".length);
 
   postEditor.removeMarkupFromRange(range, bold);
   postEditor.complete();
 
-  assert.equal(section.text, 'abcdef', 'text still correct');
-  assert.equal(section.markers.length, 2, '2 markers');
+  assert.equal(section.text, "abcdef", "text still correct");
+  assert.equal(section.markers.length, 2, "2 markers");
 
   let [head, tail] = section.markers.toArray();
-  assert.equal(head.value, 'a', 'head marker value');
-  assert.ok(head.hasMarkup(bold), 'head has bold');
-  assert.equal(tail.value, 'bcdef', 'tail marker value');
-  assert.ok(!tail.hasMarkup(bold), 'tail has no bold');
+  assert.equal(head.value, "a", "head marker value");
+  assert.ok(head.hasMarkup(bold), "head has bold");
+  assert.equal(tail.value, "bcdef", "tail marker value");
+  assert.ok(!tail.hasMarkup(bold), "tail has no bold");
 });
 
-test('#removeMarkupFromRange handles atoms correctly', (assert) => {
+test("#removeMarkupFromRange handles atoms correctly", assert => {
   let bold, section;
   let post = Helpers.postAbstract.build(
-    ({post, marker, markup, atom, markupSection}) => {
-    bold = markup('b');
-    section = markupSection('p', [
-      atom('the-atom', 'n/a', {}, [bold]),
-      marker('X')
-    ]);
-    return post([section]);
-  });
+    ({ post, marker, markup, atom, markupSection }) => {
+      bold = markup("b");
+      section = markupSection("p", [
+        atom("the-atom", "n/a", {}, [bold]),
+        marker("X")
+      ]);
+      return post([section]);
+    }
+  );
 
   renderBuiltAbstract(post, mockEditor);
 
@@ -401,146 +426,168 @@ test('#removeMarkupFromRange handles atoms correctly', (assert) => {
   postEditor.removeMarkupFromRange(range, bold);
   postEditor.complete();
 
-  assert.equal(section.markers.length, 2, '2 markers');
+  assert.equal(section.markers.length, 2, "2 markers");
 
   let [head, tail] = section.markers.toArray();
-  assert.ok(head.isAtom, 'head is atom');
-  assert.ok(!head.hasMarkup(bold), 'head has no bold');
+  assert.ok(head.isAtom, "head is atom");
+  assert.ok(!head.hasMarkup(bold), "head has no bold");
 
-  assert.equal(tail.value, 'X', 'tail marker value');
-  assert.ok(!tail.hasMarkup(bold), 'tail has no bold');
+  assert.equal(tail.value, "X", "tail marker value");
+  assert.ok(!tail.hasMarkup(bold), "tail has no bold");
 });
 
-test('#addMarkupToRange is no-op with collapsed range', (assert) => {
+test("#addMarkupToRange is no-op with collapsed range", assert => {
   let section, markup;
-  const post = Helpers.postAbstract.build(({
-    post, markupSection, marker, markup: buildMarkup
-  }) => {
-    markup = buildMarkup('strong');
-    section = markupSection('p', [
-      marker('abc')
-    ]);
-    return post([section]);
-  });
+  const post = Helpers.postAbstract.build(
+    ({ post, markupSection, marker, markup: buildMarkup }) => {
+      markup = buildMarkup("strong");
+      section = markupSection("p", [marker("abc")]);
+      return post([section]);
+    }
+  );
   renderBuiltAbstract(post, mockEditor);
 
   let range = Range.create(section, 1, section, 1);
   postEditor.addMarkupToRange(range, markup);
   postEditor.complete();
 
-  assert.equal(section.markers.length, 1, 'similar markers are coalesced');
-  assert.equal(section.markers.head.value, 'abc', 'marker value is correct');
-  assert.ok(!section.markers.head.hasMarkup(markup), 'marker has no markup');
+  assert.equal(section.markers.length, 1, "similar markers are coalesced");
+  assert.equal(section.markers.head.value, "abc", "marker value is correct");
+  assert.ok(!section.markers.head.hasMarkup(markup), "marker has no markup");
 });
 
-test("#addMarkupToRange around a markup pushes the new markup below existing ones", (assert) => {
+test("#addMarkupToRange around a markup pushes the new markup below existing ones", assert => {
   let em;
-  const editor = buildEditorWithMobiledoc(({post, markupSection, marker, markup}) => {
-    em = markup('em');
-    return post([
-        markupSection('p', [
-          marker('one '),
-          marker('BOLD', [markup('b')]),
-          marker(' two')
-      ])
-    ]);
-  });
+  const editor = buildEditorWithMobiledoc(
+    ({ post, markupSection, marker, markup }) => {
+      em = markup("em");
+      return post([
+        markupSection("p", [
+          marker("one "),
+          marker("BOLD", [markup("b")]),
+          marker(" two")
+        ])
+      ]);
+    }
+  );
 
   let section = editor.post.sections.head;
 
-  let range = Range.create(section, 0, section, 'one BOLD two'.length);
+  let range = Range.create(section, 0, section, "one BOLD two".length);
   editor.run(function(postEditor) {
     postEditor.addMarkupToRange(range, em);
   });
 
   let markers = section.markers.toArray();
-  assert.equal(markers[0].closedMarkups.length, 0,
-      'Existing markup is not closed');
+  assert.equal(
+    markers[0].closedMarkups.length,
+    0,
+    "Existing markup is not closed"
+  );
 
-  assert.equal(editor.element.innerHTML,
-      '<p><em>one <b>BOLD</b> two</em></p>');
+  assert.equal(editor.element.innerHTML, "<p><em>one <b>BOLD</b> two</em></p>");
 });
 
-
-test("#addMarkupToRange within a markup puts the new markup on top of the stack", (assert) => {
+test("#addMarkupToRange within a markup puts the new markup on top of the stack", assert => {
   let b;
-  const editor = buildEditorWithMobiledoc(({post, markupSection, marker, markup}) => {
-    b = markup('b');
-    return post([
-        markupSection('p', [
-          marker('one BOLD two', [markup('em')]),
-      ])
-    ]);
-  });
+  const editor = buildEditorWithMobiledoc(
+    ({ post, markupSection, marker, markup }) => {
+      b = markup("b");
+      return post([
+        markupSection("p", [marker("one BOLD two", [markup("em")])])
+      ]);
+    }
+  );
 
   let section = editor.post.sections.head;
 
-  let range = Range.create(section, 'one '.length, section, 'one BOLD'.length);
+  let range = Range.create(section, "one ".length, section, "one BOLD".length);
   editor.run(function(postEditor) {
     postEditor.addMarkupToRange(range, b);
   });
 
   let markers = section.markers.toArray();
-  assert.equal(markers[0].closedMarkups.length, 0,
-      'Existing markup is not closed');
+  assert.equal(
+    markers[0].closedMarkups.length,
+    0,
+    "Existing markup is not closed"
+  );
 
-  assert.equal(editor.element.innerHTML,
-      '<p><em>one <b>BOLD</b> two</em></p>');
+  assert.equal(editor.element.innerHTML, "<p><em>one <b>BOLD</b> two</em></p>");
 });
 
-test("#addMarkupToRange straddling the open tag of an existing markup, closes and reopens the existing markup", (assert) => {
+test("#addMarkupToRange straddling the open tag of an existing markup, closes and reopens the existing markup", assert => {
   let em;
-  const editor = buildEditorWithMobiledoc(({post, markupSection, marker, markup}) => {
-    em = markup('em');
-    return post([
-        markupSection('p', [
-          marker('_one '),
-          marker('TWO_ THREE', [markup('b')])
-      ])
-    ]);
-  });
+  const editor = buildEditorWithMobiledoc(
+    ({ post, markupSection, marker, markup }) => {
+      em = markup("em");
+      return post([
+        markupSection("p", [
+          marker("_one "),
+          marker("TWO_ THREE", [markup("b")])
+        ])
+      ]);
+    }
+  );
 
   let section = editor.post.sections.head;
-  let range = Range.create(section, 0, section, '_one TWO_'.length);
+  let range = Range.create(section, 0, section, "_one TWO_".length);
 
   editor.run(function(postEditor) {
     postEditor.addMarkupToRange(range, em);
   });
 
-  assert.equal(editor.element.innerHTML,
-      '<p><em>_one <b>TWO_</b></em><b> THREE</b></p>');
+  assert.equal(
+    editor.element.innerHTML,
+    "<p><em>_one <b>TWO_</b></em><b> THREE</b></p>"
+  );
 });
 
-test("#addMarkupToRange straddling the closing tag of an existing markup, closes and reopens the existing markup", (assert) => {
+test("#addMarkupToRange straddling the closing tag of an existing markup, closes and reopens the existing markup", assert => {
   let em;
-  const editor = buildEditorWithMobiledoc(({post, markupSection, marker, markup}) => {
-    em = markup('em');
-    return post([
-        markupSection('p', [
-          marker('ONE _TWO', [markup('b')]),
-          marker(' three_')
-      ])
-    ]);
-  });
+  const editor = buildEditorWithMobiledoc(
+    ({ post, markupSection, marker, markup }) => {
+      em = markup("em");
+      return post([
+        markupSection("p", [
+          marker("ONE _TWO", [markup("b")]),
+          marker(" three_")
+        ])
+      ]);
+    }
+  );
 
   let section = editor.post.sections.head;
-  let range = Range.create(section, 'ONE '.length, section, 'ONE _TWO three_'.length);
+  let range = Range.create(
+    section,
+    "ONE ".length,
+    section,
+    "ONE _TWO three_".length
+  );
 
   editor.run(function(postEditor) {
     postEditor.addMarkupToRange(range, em);
   });
 
-  assert.equal(editor.element.innerHTML,
-      '<p><b>ONE </b><em><b>_TWO</b> three_</em></p>');
+  assert.equal(
+    editor.element.innerHTML,
+    "<p><b>ONE </b><em><b>_TWO</b> three_</em></p>"
+  );
 });
 
-test('markers with identical markups get coalesced after deletion', (assert) => {
+test("markers with identical markups get coalesced after deletion", assert => {
   let strong, section;
-  const post = Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
-    strong = markup('strong');
-    section = markupSection('p', [marker('a'), marker('b',[strong]), marker('c')]);
-    return post([section]);
-  });
+  const post = Helpers.postAbstract.build(
+    ({ post, markupSection, marker, markup }) => {
+      strong = markup("strong");
+      section = markupSection("p", [
+        marker("a"),
+        marker("b", [strong]),
+        marker("c")
+      ]);
+      return post([section]);
+    }
+  );
   mockEditor = renderBuiltAbstract(post, mockEditor);
 
   let range = Range.create(section, 1, section, 2);
@@ -548,15 +595,15 @@ test('markers with identical markups get coalesced after deletion', (assert) => 
   postEditor.deleteRange(range);
   postEditor.complete();
 
-  assert.equal(section.markers.length, 1, 'similar markers are coalesced');
-  assert.equal(section.markers.head.value, 'ac', 'marker value is correct');
+  assert.equal(section.markers.length, 1, "similar markers are coalesced");
+  assert.equal(section.markers.head.value, "ac", "marker value is correct");
 });
 
-test('#moveSectionBefore moves the section as expected', (assert) => {
-  const post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+test("#moveSectionBefore moves the section as expected", assert => {
+  const post = Helpers.postAbstract.build(({ post, markupSection, marker }) => {
     return post([
-      markupSection('p', [marker('abc')]),
-      markupSection('p', [marker('123')])
+      markupSection("p", [marker("abc")]),
+      markupSection("p", [marker("123")])
     ]);
   });
   mockEditor = renderBuiltAbstract(post, mockEditor);
@@ -564,21 +611,25 @@ test('#moveSectionBefore moves the section as expected', (assert) => {
   const [headSection, tailSection] = post.sections.toArray();
   const collection = post.sections;
   postEditor = new PostEditor(mockEditor);
-  let movedSection = postEditor.moveSectionBefore(collection, tailSection, headSection);
+  let movedSection = postEditor.moveSectionBefore(
+    collection,
+    tailSection,
+    headSection
+  );
   postEditor.complete();
 
-  assert.equal(post.sections.head, movedSection, 'movedSection is returned');
-  assert.equal(post.sections.head.text, '123', 'tail section is now head');
-  assert.equal(post.sections.tail.text, 'abc', 'head section is now tail');
+  assert.equal(post.sections.head, movedSection, "movedSection is returned");
+  assert.equal(post.sections.head.text, "123", "tail section is now head");
+  assert.equal(post.sections.tail.text, "abc", "head section is now tail");
 });
 
-test('#moveSectionBefore moves card sections', (assert) => {
-  const listiclePayload = {some:'thing'};
-  const otherPayload = {some:'other thing'};
-  const post = Helpers.postAbstract.build(({post, cardSection}) => {
+test("#moveSectionBefore moves card sections", assert => {
+  const listiclePayload = { some: "thing" };
+  const otherPayload = { some: "other thing" };
+  const post = Helpers.postAbstract.build(({ post, cardSection }) => {
     return post([
-      cardSection('listicle-card', listiclePayload),
-      cardSection('other-card', otherPayload)
+      cardSection("listicle-card", listiclePayload),
+      cardSection("other-card", otherPayload)
     ]);
   });
   mockEditor = renderBuiltAbstract(post, mockEditor);
@@ -589,19 +640,32 @@ test('#moveSectionBefore moves card sections', (assert) => {
   postEditor.moveSectionBefore(collection, tailSection, headSection);
   postEditor.complete();
 
-  ([headSection, tailSection] = post.sections.toArray());
-  assert.equal(headSection.name, 'other-card', 'other-card moved to first spot');
-  assert.equal(tailSection.name, 'listicle-card', 'listicle-card moved to last spot');
-  assert.deepEqual(headSection.payload, otherPayload, 'payload is correct for other-card');
-  assert.deepEqual(tailSection.payload, listiclePayload, 'payload is correct for listicle-card');
+  [headSection, tailSection] = post.sections.toArray();
+  assert.equal(
+    headSection.name,
+    "other-card",
+    "other-card moved to first spot"
+  );
+  assert.equal(
+    tailSection.name,
+    "listicle-card",
+    "listicle-card moved to last spot"
+  );
+  assert.deepEqual(
+    headSection.payload,
+    otherPayload,
+    "payload is correct for other-card"
+  );
+  assert.deepEqual(
+    tailSection.payload,
+    listiclePayload,
+    "payload is correct for listicle-card"
+  );
 });
 
-test('#moveSectionUp moves it up', (assert) => {
-  const post = Helpers.postAbstract.build(({post, cardSection}) => {
-    return post([
-      cardSection('listicle-card'),
-      cardSection('other-card')
-    ]);
+test("#moveSectionUp moves it up", assert => {
+  const post = Helpers.postAbstract.build(({ post, cardSection }) => {
+    return post([cardSection("listicle-card"), cardSection("other-card")]);
   });
   mockEditor = renderBuiltAbstract(post, mockEditor);
 
@@ -610,25 +674,34 @@ test('#moveSectionUp moves it up', (assert) => {
   postEditor.moveSectionUp(tailSection);
   postEditor.complete();
 
-  ([headSection, tailSection] = post.sections.toArray());
-  assert.equal(headSection.name, 'other-card', 'other-card moved to first spot');
-  assert.equal(tailSection.name, 'listicle-card', 'listicle-card moved to last spot');
+  [headSection, tailSection] = post.sections.toArray();
+  assert.equal(
+    headSection.name,
+    "other-card",
+    "other-card moved to first spot"
+  );
+  assert.equal(
+    tailSection.name,
+    "listicle-card",
+    "listicle-card moved to last spot"
+  );
 
   postEditor = new PostEditor(mockEditor);
   let movedSection = postEditor.moveSectionUp(headSection);
   postEditor.complete();
 
-  ([headSection, tailSection] = post.sections.toArray());
-  assert.equal(post.sections.head, movedSection, 'movedSection is returned');
-  assert.equal(headSection.name, 'other-card', 'moveSectionUp is no-op when card is at top');
+  [headSection, tailSection] = post.sections.toArray();
+  assert.equal(post.sections.head, movedSection, "movedSection is returned");
+  assert.equal(
+    headSection.name,
+    "other-card",
+    "moveSectionUp is no-op when card is at top"
+  );
 });
 
-test('moveSectionDown moves it down', (assert) => {
-  const post = Helpers.postAbstract.build(({post, cardSection}) => {
-    return post([
-      cardSection('listicle-card'),
-      cardSection('other-card')
-    ]);
+test("moveSectionDown moves it down", assert => {
+  const post = Helpers.postAbstract.build(({ post, cardSection }) => {
+    return post([cardSection("listicle-card"), cardSection("other-card")]);
   });
   mockEditor = renderBuiltAbstract(post, mockEditor);
 
@@ -637,22 +710,33 @@ test('moveSectionDown moves it down', (assert) => {
   postEditor.moveSectionDown(headSection);
   postEditor.complete();
 
-  ([headSection, tailSection] = post.sections.toArray());
-  assert.equal(headSection.name, 'other-card', 'other-card moved to first spot');
-  assert.equal(tailSection.name, 'listicle-card', 'listicle-card moved to last spot');
+  [headSection, tailSection] = post.sections.toArray();
+  assert.equal(
+    headSection.name,
+    "other-card",
+    "other-card moved to first spot"
+  );
+  assert.equal(
+    tailSection.name,
+    "listicle-card",
+    "listicle-card moved to last spot"
+  );
 
   postEditor = new PostEditor(mockEditor);
   let movedSection = postEditor.moveSectionDown(tailSection);
   postEditor.complete();
 
-  ([headSection, tailSection] = post.sections.toArray());
-  assert.equal(post.sections.tail, movedSection, 'movedSection is returned');
-  assert.equal(tailSection.name, 'listicle-card',
-               'moveSectionDown is no-op when card is at bottom');
+  [headSection, tailSection] = post.sections.toArray();
+  assert.equal(post.sections.tail, movedSection, "movedSection is returned");
+  assert.equal(
+    tailSection.name,
+    "listicle-card",
+    "moveSectionDown is no-op when card is at bottom"
+  );
 });
 
-test('#setAttribute on empty Mobiledoc does nothing', (assert) => {
-  let post = Helpers.postAbstract.build(({post, markupSection}) => {
+test("#setAttribute on empty Mobiledoc does nothing", assert => {
+  let post = Helpers.postAbstract.build(({ post, markupSection }) => {
     return post([]);
   });
 
@@ -660,886 +744,1018 @@ test('#setAttribute on empty Mobiledoc does nothing', (assert) => {
   const range = Range.blankRange();
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.setAttribute('text-align', 'center', range);
+  postEditor.setAttribute("text-align", "center", range);
   postEditor.complete();
 
   assert.postIsSimilar(postEditor.editor.post, post);
 });
 
-test('#setAttribute sets attribute of a single section', (assert) => {
-  let post = Helpers.postAbstract.build(({post, markupSection}) => {
-    return post([markupSection('p')]);
+test("#setAttribute sets attribute of a single section", assert => {
+  let post = Helpers.postAbstract.build(({ post, markupSection }) => {
+    return post([markupSection("p")]);
   });
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
   const range = Range.create(post.sections.head, 0);
 
-  assert.deepEqual(
-    post.sections.head.attributes,
-    {}
-  );
+  assert.deepEqual(post.sections.head.attributes, {});
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.setAttribute('text-align', 'center', range);
+  postEditor.setAttribute("text-align", "center", range);
   postEditor.complete();
 
-  assert.deepEqual(
-    post.sections.head.attributes,
-    {
-      'data-md-text-align': 'center'
-    }
-  );
+  assert.deepEqual(post.sections.head.attributes, {
+    "data-md-text-align": "center"
+  });
 });
 
-test('#removeAttribute removes attribute of a single section', (assert) => {
-  let post = Helpers.postAbstract.build(({post, markupSection}) => {
-    return post([markupSection('p', [], false, { 'data-md-text-align': 'center' })]);
+test("#removeAttribute removes attribute of a single section", assert => {
+  let post = Helpers.postAbstract.build(({ post, markupSection }) => {
+    return post([
+      markupSection("p", [], false, { "data-md-text-align": "center" })
+    ]);
   });
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
   const range = Range.create(post.sections.head, 0);
 
-  assert.deepEqual(
-    post.sections.head.attributes,
-    {
-      'data-md-text-align': 'center'
-    }
-  );
+  assert.deepEqual(post.sections.head.attributes, {
+    "data-md-text-align": "center"
+  });
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.removeAttribute('text-align', range);
+  postEditor.removeAttribute("text-align", range);
   postEditor.complete();
 
-  assert.deepEqual(
-    post.sections.head.attributes,
-    {}
-  );
+  assert.deepEqual(post.sections.head.attributes, {});
 });
 
-test('#setAttribute sets attribute of multiple sections', (assert) => {
+test("#setAttribute sets attribute of multiple sections", assert => {
   let post = Helpers.postAbstract.build(
-    ({post, markupSection, marker, cardSection}) => {
-    return post([
-      markupSection('p', [marker('abc')]),
-      cardSection('my-card'),
-      markupSection('p', [marker('123')])
-    ]);
-  });
+    ({ post, markupSection, marker, cardSection }) => {
+      return post([
+        markupSection("p", [marker("abc")]),
+        cardSection("my-card"),
+        markupSection("p", [marker("123")])
+      ]);
+    }
+  );
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
-  const range = Range.create(post.sections.head, 0,
-                             post.sections.tail, 2);
+  const range = Range.create(post.sections.head, 0, post.sections.tail, 2);
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.setAttribute('text-align', 'center', range);
+  postEditor.setAttribute("text-align", "center", range);
   postEditor.complete();
 
-  assert.deepEqual(
-    post.sections.head.attributes,
-    {
-      'data-md-text-align': 'center'
-    }
-  );
+  assert.deepEqual(post.sections.head.attributes, {
+    "data-md-text-align": "center"
+  });
   assert.ok(post.sections.objectAt(1).isCardSection);
-  assert.deepEqual(
-    post.sections.tail.attributes,
-    {
-      'data-md-text-align': 'center'
-    }
-  );
+  assert.deepEqual(post.sections.tail.attributes, {
+    "data-md-text-align": "center"
+  });
 });
 
-test('#removeAttribute removes attribute of multiple sections', (assert) => {
+test("#removeAttribute removes attribute of multiple sections", assert => {
   let post = Helpers.postAbstract.build(
-    ({post, markupSection, marker, cardSection}) => {
-    return post([
-      markupSection('p', [marker('abc')], false, { 'data-md-text-align': 'center' }),
-      cardSection('my-card'),
-      markupSection('p', [marker('123')], { 'data-md-text-align': 'left' })
-    ]);
-  });
+    ({ post, markupSection, marker, cardSection }) => {
+      return post([
+        markupSection("p", [marker("abc")], false, {
+          "data-md-text-align": "center"
+        }),
+        cardSection("my-card"),
+        markupSection("p", [marker("123")], { "data-md-text-align": "left" })
+      ]);
+    }
+  );
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
-  const range = Range.create(post.sections.head, 0,
-                             post.sections.tail, 2);
+  const range = Range.create(post.sections.head, 0, post.sections.tail, 2);
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.removeAttribute('text-align', range);
+  postEditor.removeAttribute("text-align", range);
   postEditor.complete();
 
-  assert.deepEqual(
-    post.sections.head.attributes,
-    {}
-  );
+  assert.deepEqual(post.sections.head.attributes, {});
   assert.ok(post.sections.objectAt(1).isCardSection);
-  assert.deepEqual(
-    post.sections.tail.attributes,
-    {}
-  );
+  assert.deepEqual(post.sections.tail.attributes, {});
 });
 
-test('#setAttribute sets attribute of a single list', (assert) => {
+test("#setAttribute sets attribute of a single list", assert => {
   let post = Helpers.postAbstract.build(
-    ({post, listSection, listItem, marker, markup}) => {
-    return post([listSection('ul', [
-      listItem([marker('a')]),
-      listItem([marker('def')]),
-    ])]);
-  });
+    ({ post, listSection, listItem, marker, markup }) => {
+      return post([
+        listSection("ul", [listItem([marker("a")]), listItem([marker("def")])])
+      ]);
+    }
+  );
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
   let range = Range.create(post.sections.head.items.head, 0);
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.setAttribute('text-align', 'center', range);
+  postEditor.setAttribute("text-align", "center", range);
   postEditor.complete();
 
-  assert.deepEqual(
-    post.sections.head.attributes,
-    {
-      'data-md-text-align': 'center'
-    }
-  );
+  assert.deepEqual(post.sections.head.attributes, {
+    "data-md-text-align": "center"
+  });
 });
 
-test('#setAttribute when cursor is in non-markerable section changes nothing', (assert) => {
+test("#setAttribute when cursor is in non-markerable section changes nothing", assert => {
   let post = Helpers.postAbstract.build(
-    ({post, markupSection, marker, cardSection}) => {
-    return post([
-      cardSection('my-card')
-    ]);
-  });
+    ({ post, markupSection, marker, cardSection }) => {
+      return post([cardSection("my-card")]);
+    }
+  );
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
   const range = post.sections.head.headPosition().toRange();
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.setAttribute('text-align', 'center', range);
+  postEditor.setAttribute("text-align", "center", range);
   postEditor.complete();
 
-  assert.ok(post.sections.head.isCardSection, 'card section not changed');
-  assert.positionIsEqual(mockEditor._renderedRange.head, post.sections.head.headPosition());
+  assert.ok(post.sections.head.isCardSection, "card section not changed");
+  assert.positionIsEqual(
+    mockEditor._renderedRange.head,
+    post.sections.head.headPosition()
+  );
 });
 
-test('#toggleSection changes single section to and from tag name', (assert) => {
-  let post = Helpers.postAbstract.build(({post, markupSection}) => {
-    return post([markupSection('p')]);
+test("#toggleSection changes single section to and from tag name", assert => {
+  let post = Helpers.postAbstract.build(({ post, markupSection }) => {
+    return post([markupSection("p")]);
   });
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
   const range = Range.create(post.sections.head, 0);
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('blockquote', range);
+  postEditor.toggleSection("blockquote", range);
   postEditor.complete();
 
-  assert.equal(post.sections.head.tagName, 'blockquote');
+  assert.equal(post.sections.head.tagName, "blockquote");
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('blockquote', range);
+  postEditor.toggleSection("blockquote", range);
   postEditor.complete();
 
-  assert.equal(post.sections.head.tagName, 'p');
-  assert.positionIsEqual(mockEditor._renderedRange.head, post.sections.head.headPosition());
+  assert.equal(post.sections.head.tagName, "p");
+  assert.positionIsEqual(
+    mockEditor._renderedRange.head,
+    post.sections.head.headPosition()
+  );
 });
 
-test('#toggleSection changes multiple sections to and from tag name', (assert) => {
-  let post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+test("#toggleSection changes multiple sections to and from tag name", assert => {
+  let post = Helpers.postAbstract.build(({ post, markupSection, marker }) => {
     return post([
-      markupSection('p', [marker('abc')]),
-      markupSection('p', [marker('123')])
+      markupSection("p", [marker("abc")]),
+      markupSection("p", [marker("123")])
     ]);
   });
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
-  const range = Range.create(post.sections.head, 2,
-                             post.sections.tail, 2);
+  const range = Range.create(post.sections.head, 2, post.sections.tail, 2);
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('blockquote', range);
+  postEditor.toggleSection("blockquote", range);
   postEditor.complete();
 
-  assert.equal(post.sections.head.tagName, 'blockquote');
-  assert.equal(post.sections.tail.tagName, 'blockquote');
+  assert.equal(post.sections.head.tagName, "blockquote");
+  assert.equal(post.sections.tail.tagName, "blockquote");
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('blockquote', range);
+  postEditor.toggleSection("blockquote", range);
   postEditor.complete();
 
-  assert.equal(post.sections.head.tagName, 'p');
-  assert.equal(post.sections.tail.tagName, 'p');
+  assert.equal(post.sections.head.tagName, "p");
+  assert.equal(post.sections.tail.tagName, "p");
 
   assert.positionIsEqual(
     mockEditor._renderedRange.head,
     post.sections.head.toPosition(2),
-    'Maintains the selection'
+    "Maintains the selection"
   );
   assert.positionIsEqual(
     mockEditor._renderedRange.tail,
     post.sections.tail.toPosition(2),
-    'Maintains the selection'
+    "Maintains the selection"
   );
 });
 
-test('#toggleSection skips over non-markerable sections', (assert) => {
-  let post = Helpers.postAbstract.build(
-    ({post, markupSection, marker, cardSection}) => {
+test("#toggleSection does not update tail markup if tail offset is 0", assert => {
+  let post = Helpers.postAbstract.build(({ post, markupSection, marker }) => {
     return post([
-      markupSection('p', [marker('abc')]),
-      cardSection('my-card'),
-      markupSection('p', [marker('123')])
+      markupSection("p", [marker("abc")]),
+      markupSection("p", [marker("123")])
     ]);
   });
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
-  const range = Range.create(post.sections.head, 0,
-                             post.sections.tail, 2);
+  const range = Range.create(post.sections.head, 2, post.sections.tail, 0);
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('blockquote', range);
+  postEditor.toggleSection("blockquote", range);
   postEditor.complete();
 
-  assert.equal(post.sections.head.tagName, 'blockquote');
-  assert.ok(post.sections.objectAt(1).isCardSection);
-  assert.equal(post.sections.tail.tagName, 'blockquote');
+  assert.equal(post.sections.head.tagName, "blockquote");
+  assert.equal(post.sections.tail.tagName, "p");
 
-  assert.positionIsEqual(mockEditor._renderedRange.head, post.sections.head.headPosition());
+  postEditor = new PostEditor(mockEditor);
+  postEditor.toggleSection("blockquote", range);
+  postEditor.complete();
+
+  assert.equal(post.sections.head.tagName, "p");
+  assert.equal(post.sections.tail.tagName, "p");
+
+  assert.positionIsEqual(
+    mockEditor._renderedRange.head,
+    post.sections.head.toPosition(2),
+    "Maintains the selection"
+  );
+  assert.positionIsEqual(
+    mockEditor._renderedRange.tail,
+    post.sections.tail.toPosition(0),
+    "Maintains the selection"
+  );
 });
 
-test('#toggleSection when cursor is in non-markerable section changes nothing', (assert) => {
+test("#toggleSection skips over non-markerable sections", assert => {
   let post = Helpers.postAbstract.build(
-    ({post, markupSection, marker, cardSection}) => {
-    return post([
-      cardSection('my-card')
-    ]);
-  });
+    ({ post, markupSection, marker, cardSection }) => {
+      return post([
+        markupSection("p", [marker("abc")]),
+        cardSection("my-card"),
+        markupSection("p", [marker("123")])
+      ]);
+    }
+  );
+
+  mockEditor = renderBuiltAbstract(post, mockEditor);
+  const range = Range.create(post.sections.head, 0, post.sections.tail, 2);
+
+  postEditor = new PostEditor(mockEditor);
+  postEditor.toggleSection("blockquote", range);
+  postEditor.complete();
+
+  assert.equal(post.sections.head.tagName, "blockquote");
+  assert.ok(post.sections.objectAt(1).isCardSection);
+  assert.equal(post.sections.tail.tagName, "blockquote");
+
+  assert.positionIsEqual(
+    mockEditor._renderedRange.head,
+    post.sections.head.headPosition()
+  );
+});
+
+test("#toggleSection when cursor is in non-markerable section changes nothing", assert => {
+  let post = Helpers.postAbstract.build(
+    ({ post, markupSection, marker, cardSection }) => {
+      return post([cardSection("my-card")]);
+    }
+  );
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
   const range = post.sections.head.headPosition().toRange();
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('blockquote', range);
+  postEditor.toggleSection("blockquote", range);
   postEditor.complete();
 
-  assert.ok(post.sections.head.isCardSection, 'card section not changed');
-  assert.positionIsEqual(mockEditor._renderedRange.head, post.sections.head.headPosition());
+  assert.ok(post.sections.head.isCardSection, "card section not changed");
+  assert.positionIsEqual(
+    mockEditor._renderedRange.head,
+    post.sections.head.headPosition()
+  );
 });
 
-test('#toggleSection when editor has no cursor does nothing', (assert) => {
+test("#toggleSection when editor has no cursor does nothing", assert => {
   assert.expect(6);
   let done = assert.async();
 
-  editor = buildEditorWithMobiledoc(
-    ({post, markupSection, marker}) => {
-    return post([markupSection('p', [marker('abc')])]);
+  editor = buildEditorWithMobiledoc(({ post, markupSection, marker }) => {
+    return post([markupSection("p", [marker("abc")])]);
   }, false);
   let expected = Helpers.postAbstract.build(
-    ({post, markupSection, marker}) => {
-    return post([markupSection('p', [marker('abc')])]);
-  });
+    ({ post, markupSection, marker }) => {
+      return post([markupSection("p", [marker("abc")])]);
+    }
+  );
 
-  assert.ok(!editor.hasCursor(), 'editor has no cursor');
-  assert.ok(editor.range.isBlank, 'editor has blank range');
+  assert.ok(!editor.hasCursor(), "editor has no cursor");
+  assert.ok(editor.range.isBlank, "editor has blank range");
 
-  editor.run(postEditor => postEditor.toggleSection('blockquote'));
+  editor.run(postEditor => postEditor.toggleSection("blockquote"));
 
   Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected);
-    assert.ok(document.activeElement !== editorElement,
-              'editor element is not active');
-    assert.ok(editor.range.isBlank, 'rendered range is blank');
-    assert.equal(window.getSelection().rangeCount, 0, 'nothing selected');
+    assert.ok(
+      document.activeElement !== editorElement,
+      "editor element is not active"
+    );
+    assert.ok(editor.range.isBlank, "rendered range is blank");
+    assert.equal(window.getSelection().rangeCount, 0, "nothing selected");
 
     done();
   });
 });
 
-test('#toggleSection toggle single p -> list item', (assert) => {
+test("#toggleSection toggle single p -> list item", assert => {
   let post = Helpers.postAbstract.build(
-    ({post, markupSection, marker, markup}) => {
-    return post([
-      markupSection('p', [marker('a'), marker('b', [markup('b')]), marker('c')])
-    ]);
-  });
+    ({ post, markupSection, marker, markup }) => {
+      return post([
+        markupSection("p", [
+          marker("a"),
+          marker("b", [markup("b")]),
+          marker("c")
+        ])
+      ]);
+    }
+  );
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
   let range = Range.create(post.sections.head, 0);
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('ul', range);
+  postEditor.toggleSection("ul", range);
   postEditor.complete();
 
   assert.equal(post.sections.length, 1);
   let listSection = post.sections.head;
   assert.ok(listSection.isListSection);
-  assert.equal(listSection.tagName, 'ul');
+  assert.equal(listSection.tagName, "ul");
   assert.equal(listSection.items.length, 1);
-  assert.equal(listSection.items.head.text, 'abc');
+  assert.equal(listSection.items.head.text, "abc");
   let item = listSection.items.head;
   assert.equal(item.markers.length, 3);
-  assert.equal(item.markers.objectAt(0).value, 'a');
-  assert.equal(item.markers.objectAt(1).value, 'b');
-  assert.ok(item.markers.objectAt(1).hasMarkup('b'), 'b has b markup');
-  assert.equal(item.markers.objectAt(2).value, 'c');
+  assert.equal(item.markers.objectAt(0).value, "a");
+  assert.equal(item.markers.objectAt(1).value, "b");
+  assert.ok(item.markers.objectAt(1).hasMarkup("b"), "b has b markup");
+  assert.equal(item.markers.objectAt(2).value, "c");
 });
 
-test('#toggleSection toggle single list item -> p', (assert) => {
+test("#toggleSection toggle single list item -> p", assert => {
   let post = Helpers.postAbstract.build(
-    ({post, listSection, listItem, marker, markup}) => {
-    return post([listSection('ul', [
-      listItem([marker('a'), marker('b', [markup('b')]), marker('c')])
-    ])]);
-  });
+    ({ post, listSection, listItem, marker, markup }) => {
+      return post([
+        listSection("ul", [
+          listItem([marker("a"), marker("b", [markup("b")]), marker("c")])
+        ])
+      ]);
+    }
+  );
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
   let range = Range.create(post.sections.head.items.head, 0);
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('ul', range);
+  postEditor.toggleSection("ul", range);
   postEditor.complete();
 
   assert.equal(post.sections.length, 1);
-  assert.equal(post.sections.head.tagName, 'p');
-  assert.equal(post.sections.head.text, 'abc');
+  assert.equal(post.sections.head.tagName, "p");
+  assert.equal(post.sections.head.text, "abc");
   assert.equal(post.sections.head.markers.length, 3);
-  assert.equal(post.sections.head.markers.objectAt(0).value, 'a');
-  assert.equal(post.sections.head.markers.objectAt(1).value, 'b');
-  assert.ok(post.sections.head.markers.objectAt(1).hasMarkup('b'), 'b has b markup');
-  assert.equal(post.sections.head.markers.objectAt(2).value, 'c');
+  assert.equal(post.sections.head.markers.objectAt(0).value, "a");
+  assert.equal(post.sections.head.markers.objectAt(1).value, "b");
+  assert.ok(
+    post.sections.head.markers.objectAt(1).hasMarkup("b"),
+    "b has b markup"
+  );
+  assert.equal(post.sections.head.markers.objectAt(2).value, "c");
 
-  assert.positionIsEqual(mockEditor._renderedRange.head, post.sections.head.headPosition());
+  assert.positionIsEqual(
+    mockEditor._renderedRange.head,
+    post.sections.head.headPosition()
+  );
 });
 
-test('#toggleSection toggle multiple ps -> list and list -> multiple ps', (assert) => {
-  let mobiledoc = Helpers.mobiledoc.build(
-    ({post, markupSection, marker}) => {
+test("#toggleSection toggle multiple ps -> list and list -> multiple ps", assert => {
+  let mobiledoc = Helpers.mobiledoc.build(({ post, markupSection, marker }) => {
     return post([
-      markupSection('p', [marker('abc')]),
-      markupSection('p', [marker('123')])
+      markupSection("p", [marker("abc")]),
+      markupSection("p", [marker("123")])
     ]);
   });
 
-  editor = new Editor({mobiledoc});
+  editor = new Editor({ mobiledoc });
   let { post } = editor;
   editor.render(editorElement);
   let range = Range.create(post.sections.head, 0, post.sections.tail, 2);
 
   postEditor = new PostEditor(editor);
-  postEditor.toggleSection('ul', range);
+  postEditor.toggleSection("ul", range);
   postEditor.complete();
 
   let listSection = post.sections.head;
-  assert.equal(post.sections.length, 1, 'post has 1 list section after toggle');
+  assert.equal(post.sections.length, 1, "post has 1 list section after toggle");
   assert.ok(listSection.isListSection);
-  assert.equal(listSection.tagName, 'ul');
-  assert.equal(listSection.items.length, 2, '2 list items');
-  assert.equal(listSection.items.head.text, 'abc');
-  assert.equal(listSection.items.tail.text, '123');
+  assert.equal(listSection.tagName, "ul");
+  assert.equal(listSection.items.length, 2, "2 list items");
+  assert.equal(listSection.items.head.text, "abc");
+  assert.equal(listSection.items.tail.text, "123");
 
   range = Range.create(listSection.items.head, 0, listSection.items.tail, 0);
   postEditor = new PostEditor(editor);
-  postEditor.toggleSection('ul', range);
+  postEditor.toggleSection("ul", range);
   postEditor.complete();
 
-  assert.equal(post.sections.length, 2, 'post has 2 sections after toggle');
-  assert.equal(post.sections.head.tagName, 'p');
-  assert.equal(post.sections.tail.tagName, 'p');
-  assert.equal(post.sections.head.text, 'abc');
-  assert.equal(post.sections.tail.text, '123');
+  assert.equal(post.sections.length, 2, "post has 2 sections after toggle");
+  assert.equal(post.sections.head.tagName, "p");
+  assert.equal(post.sections.tail.tagName, "p");
+  assert.equal(post.sections.head.text, "abc");
+  assert.equal(post.sections.tail.text, "123");
 
-  assert.ok(editor.range.head.section === post.sections.head,
-            'selected head correct');
+  assert.ok(
+    editor.range.head.section === post.sections.head,
+    "selected head correct"
+  );
   assert.equal(editor.range.head.offset, 0);
 });
 
-test('#toggleSection untoggle first list item changes it to markup section, retains markup', (assert) => {
+test("#toggleSection untoggle first list item changes it to markup section, retains markup", assert => {
   let post = Helpers.postAbstract.build(
-    ({post, listSection, listItem, marker, markup}) => {
-    return post([listSection('ul', [
-      listItem([marker('a'), marker('b', [markup('b')]), marker('c')]),
-      listItem([marker('def')]),
-      listItem([marker('ghi')])
-    ])]);
-  });
+    ({ post, listSection, listItem, marker, markup }) => {
+      return post([
+        listSection("ul", [
+          listItem([marker("a"), marker("b", [markup("b")]), marker("c")]),
+          listItem([marker("def")]),
+          listItem([marker("ghi")])
+        ])
+      ]);
+    }
+  );
   mockEditor = renderBuiltAbstract(post, mockEditor);
   let range = Range.create(post.sections.head.items.head, 0);
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('ul', range);
+  postEditor.toggleSection("ul", range);
   postEditor.complete();
 
-  assert.equal(post.sections.length, 2, '2 sections');
-  assert.equal(post.sections.head.tagName, 'p', 'head section is p');
-  assert.equal(post.sections.head.text, 'abc');
+  assert.equal(post.sections.length, 2, "2 sections");
+  assert.equal(post.sections.head.tagName, "p", "head section is p");
+  assert.equal(post.sections.head.text, "abc");
   let section = post.sections.head;
   assert.equal(section.markers.length, 3);
-  assert.equal(section.markers.objectAt(0).value, 'a');
-  assert.ok(section.markers.objectAt(1).hasMarkup('b'), 'b has b markup');
-  assert.equal(section.markers.objectAt(2).value, 'c');
-  assert.ok(post.sections.tail.isListSection, 'tail is list section');
-  assert.equal(post.sections.tail.items.length, 2, '2 items in list');
-  assert.equal(post.sections.tail.items.head.text, 'def');
-  assert.equal(post.sections.tail.items.tail.text, 'ghi');
+  assert.equal(section.markers.objectAt(0).value, "a");
+  assert.ok(section.markers.objectAt(1).hasMarkup("b"), "b has b markup");
+  assert.equal(section.markers.objectAt(2).value, "c");
+  assert.ok(post.sections.tail.isListSection, "tail is list section");
+  assert.equal(post.sections.tail.items.length, 2, "2 items in list");
+  assert.equal(post.sections.tail.items.head.text, "def");
+  assert.equal(post.sections.tail.items.tail.text, "ghi");
 
-  assert.positionIsEqual(mockEditor._renderedRange.head, post.sections.head.headPosition());
+  assert.positionIsEqual(
+    mockEditor._renderedRange.head,
+    post.sections.head.headPosition()
+  );
 });
 
-test('#toggleSection untoggle middle list item changes it to markup section, retaining markup', (assert) => {
+test("#toggleSection untoggle middle list item changes it to markup section, retaining markup", assert => {
   let post = Helpers.postAbstract.build(
-    ({post, listSection, listItem, marker, markup}) => {
-    return post([listSection('ul', [
-      listItem([marker('abc')]),
-      listItem([marker('d'), marker('e', [markup('b')]), marker('f')]),
-      listItem([marker('ghi')])
-    ])]);
-  });
+    ({ post, listSection, listItem, marker, markup }) => {
+      return post([
+        listSection("ul", [
+          listItem([marker("abc")]),
+          listItem([marker("d"), marker("e", [markup("b")]), marker("f")]),
+          listItem([marker("ghi")])
+        ])
+      ]);
+    }
+  );
   mockEditor = renderBuiltAbstract(post, mockEditor);
   let range = Range.create(post.sections.head.items.objectAt(1), 0);
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('ul', range);
+  postEditor.toggleSection("ul", range);
   postEditor.complete();
 
-  assert.equal(post.sections.length, 3, '3 sections');
+  assert.equal(post.sections.length, 3, "3 sections");
   let section = post.sections.objectAt(1);
-  assert.equal(section.tagName, 'p', 'middle section is p');
-  assert.equal(section.text, 'def');
+  assert.equal(section.tagName, "p", "middle section is p");
+  assert.equal(section.text, "def");
   assert.equal(section.markers.length, 3);
-  assert.equal(section.markers.objectAt(0).value, 'd');
-  assert.equal(section.markers.objectAt(1).value, 'e');
-  assert.ok(section.markers.objectAt(1).hasMarkup('b'), 'e has b markup');
-  assert.equal(section.markers.objectAt(2).value, 'f');
-  assert.positionIsEqual(mockEditor._renderedRange.head, section.headPosition());
+  assert.equal(section.markers.objectAt(0).value, "d");
+  assert.equal(section.markers.objectAt(1).value, "e");
+  assert.ok(section.markers.objectAt(1).hasMarkup("b"), "e has b markup");
+  assert.equal(section.markers.objectAt(2).value, "f");
+  assert.positionIsEqual(
+    mockEditor._renderedRange.head,
+    section.headPosition()
+  );
 
-  assert.ok(post.sections.head.isListSection, 'head section is list');
-  assert.ok(post.sections.tail.isListSection, 'tail section is list');
-  assert.equal(post.sections.head.items.length, 1, '1 item in first list');
-  assert.equal(post.sections.tail.items.length, 1, '1 item in last list');
-  assert.equal(post.sections.head.items.head.text, 'abc');
-  assert.equal(post.sections.tail.items.head.text, 'ghi');
+  assert.ok(post.sections.head.isListSection, "head section is list");
+  assert.ok(post.sections.tail.isListSection, "tail section is list");
+  assert.equal(post.sections.head.items.length, 1, "1 item in first list");
+  assert.equal(post.sections.tail.items.length, 1, "1 item in last list");
+  assert.equal(post.sections.head.items.head.text, "abc");
+  assert.equal(post.sections.tail.items.head.text, "ghi");
 });
 
-test('#toggleSection toggle markup section -> ul between lists joins the lists', (assert) => {
+test("#toggleSection toggle markup section -> ul between lists joins the lists", assert => {
   let mobiledoc = Helpers.mobiledoc.build(
-    ({post, listSection, listItem, marker, markupSection}) => {
-    return post([
-      listSection('ul', [listItem([marker('abc')])]),
-      markupSection('p', [marker('123')]),
-      listSection('ul', [listItem([marker('def')])])
-    ]);
-  });
-  editor = new Editor({mobiledoc});
+    ({ post, listSection, listItem, marker, markupSection }) => {
+      return post([
+        listSection("ul", [listItem([marker("abc")])]),
+        markupSection("p", [marker("123")]),
+        listSection("ul", [listItem([marker("def")])])
+      ]);
+    }
+  );
+  editor = new Editor({ mobiledoc });
   let { post } = editor;
   editor.render(editorElement);
   let range = Range.create(post.sections.objectAt(1), 0);
 
   postEditor = new PostEditor(editor);
-  postEditor.toggleSection('ul', range);
+  postEditor.toggleSection("ul", range);
   postEditor.complete();
 
-  assert.equal(post.sections.length, 1, '1 sections');
+  assert.equal(post.sections.length, 1, "1 sections");
   let section = post.sections.head;
-  assert.ok(section.isListSection, 'list section');
-  assert.equal(section.items.length, 3, '3 items');
-  assert.deepEqual(section.items.map(i => i.text), ['abc', '123', 'def']);
+  assert.ok(section.isListSection, "list section");
+  assert.equal(section.items.length, 3, "3 items");
+  assert.deepEqual(
+    section.items.map(i => i.text),
+    ["abc", "123", "def"]
+  );
 
   let listItem = section.items.objectAt(1);
-  assert.ok(editor.range.head.section === listItem, 'correct head selection');
+  assert.ok(editor.range.head.section === listItem, "correct head selection");
   assert.equal(editor.range.head.offset, 0);
 });
 
-test('#toggleSection untoggle multiple items at end of list changes them to markup sections', (assert) => {
+test("#toggleSection untoggle multiple items at end of list changes them to markup sections", assert => {
   let post = Helpers.postAbstract.build(
-    ({post, listSection, listItem, marker}) => {
-    return post([listSection('ul', [
-      listItem([marker('abc')]),
-      listItem([marker('def')]),
-      listItem([marker('ghi')])
-    ])]);
-  });
+    ({ post, listSection, listItem, marker }) => {
+      return post([
+        listSection("ul", [
+          listItem([marker("abc")]),
+          listItem([marker("def")]),
+          listItem([marker("ghi")])
+        ])
+      ]);
+    }
+  );
   mockEditor = renderBuiltAbstract(post, mockEditor);
-  let range = Range.create(post.sections.head.items.objectAt(1), 0,
-                           post.sections.head.items.tail, 0);
+  let range = Range.create(
+    post.sections.head.items.objectAt(1),
+    0,
+    post.sections.head.items.tail,
+    0
+  );
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('ul', range);
+  postEditor.toggleSection("ul", range);
   postEditor.complete();
 
-  assert.equal(post.sections.length, 3, '3 sections');
-  assert.ok(post.sections.head.isListSection, 'head section is list');
-  assert.equal(post.sections.head.items.length, 1, 'head section has 1 item');
-  assert.equal(post.sections.head.items.head.text, 'abc');
+  assert.equal(post.sections.length, 3, "3 sections");
+  assert.ok(post.sections.head.isListSection, "head section is list");
+  assert.equal(post.sections.head.items.length, 1, "head section has 1 item");
+  assert.equal(post.sections.head.items.head.text, "abc");
 
-  assert.equal(post.sections.objectAt(1).tagName, 'p', 'middle is p');
-  assert.equal(post.sections.objectAt(1).text, 'def');
-  assert.equal(post.sections.tail.tagName, 'p', 'tail is p');
-  assert.equal(post.sections.tail.text, 'ghi');
+  assert.equal(post.sections.objectAt(1).tagName, "p", "middle is p");
+  assert.equal(post.sections.objectAt(1).text, "def");
+  assert.equal(post.sections.tail.tagName, "p", "tail is p");
+  assert.equal(post.sections.tail.text, "ghi");
 
-  assert.positionIsEqual(mockEditor._renderedRange.head, post.sections.objectAt(1).headPosition());
+  assert.positionIsEqual(
+    mockEditor._renderedRange.head,
+    post.sections.objectAt(1).headPosition()
+  );
 });
 
-test('#toggleSection untoggle multiple items at start of list changes them to markup sections', (assert) => {
+test("#toggleSection untoggle multiple items at start of list changes them to markup sections", assert => {
   let post = Helpers.postAbstract.build(
-    ({post, listSection, listItem, marker}) => {
-    return post([listSection('ul', [
-      listItem([marker('abc')]),
-      listItem([marker('def')]),
-      listItem([marker('ghi')])
-    ])]);
-  });
+    ({ post, listSection, listItem, marker }) => {
+      return post([
+        listSection("ul", [
+          listItem([marker("abc")]),
+          listItem([marker("def")]),
+          listItem([marker("ghi")])
+        ])
+      ]);
+    }
+  );
   mockEditor = renderBuiltAbstract(post, mockEditor);
-  let range = Range.create(post.sections.head.items.head, 0,
-                           post.sections.head.items.objectAt(1), 0);
+  let range = Range.create(
+    post.sections.head.items.head,
+    0,
+    post.sections.head.items.objectAt(1),
+    0
+  );
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('ul', range);
+  postEditor.toggleSection("ul", range);
   postEditor.complete();
 
-  assert.equal(post.sections.length, 3, '3 sections');
-  assert.equal(post.sections.head.tagName, 'p', 'head section is p');
-  assert.equal(post.sections.head.text, 'abc');
+  assert.equal(post.sections.length, 3, "3 sections");
+  assert.equal(post.sections.head.tagName, "p", "head section is p");
+  assert.equal(post.sections.head.text, "abc");
 
-  assert.equal(post.sections.objectAt(1).tagName, 'p', '2nd section is p');
-  assert.equal(post.sections.objectAt(1).text, 'def');
+  assert.equal(post.sections.objectAt(1).tagName, "p", "2nd section is p");
+  assert.equal(post.sections.objectAt(1).text, "def");
 
-  assert.ok(post.sections.objectAt(2).isListSection, '3rd section is list');
-  assert.equal(post.sections.objectAt(2).items.length, 1, 'list has 1 item');
-  assert.equal(post.sections.objectAt(2).items.head.text, 'ghi');
+  assert.ok(post.sections.objectAt(2).isListSection, "3rd section is list");
+  assert.equal(post.sections.objectAt(2).items.length, 1, "list has 1 item");
+  assert.equal(post.sections.objectAt(2).items.head.text, "ghi");
 
-  assert.positionIsEqual(mockEditor._renderedRange.head, post.sections.head.headPosition());
+  assert.positionIsEqual(
+    mockEditor._renderedRange.head,
+    post.sections.head.headPosition()
+  );
 });
 
-test('#toggleSection untoggle items and overflowing markup sections changes the overflow to items', (assert) => {
+test("#toggleSection untoggle items and overflowing markup sections changes the overflow to items", assert => {
   let mobiledoc = Helpers.mobiledoc.build(
-    ({post, listSection, listItem, markupSection, marker}) => {
-    return post([
-      listSection('ul', [
-        listItem([marker('abc')]),
-        listItem([marker('def')]),
-        listItem([marker('ghi')])
-      ]),
-      markupSection('p', [marker('123')])
-    ]);
-  });
-  editor = new Editor({mobiledoc});
+    ({ post, listSection, listItem, markupSection, marker }) => {
+      return post([
+        listSection("ul", [
+          listItem([marker("abc")]),
+          listItem([marker("def")]),
+          listItem([marker("ghi")])
+        ]),
+        markupSection("p", [marker("123")])
+      ]);
+    }
+  );
+  editor = new Editor({ mobiledoc });
   editor.render(editorElement);
   let { post } = editor;
-  let range = Range.create(post.sections.head.items.objectAt(1), 0,
-                           post.sections.tail, 0);
+  let range = Range.create(
+    post.sections.head.items.objectAt(1),
+    0,
+    post.sections.tail,
+    0
+  );
 
   postEditor = new PostEditor(editor);
-  postEditor.toggleSection('ul', range);
+  postEditor.toggleSection("ul", range);
   postEditor.complete();
 
-  assert.equal(post.sections.length, 1, '1 section');
-  assert.ok(post.sections.head.isListSection, 'head section is list');
-  assert.equal(post.sections.head.items.length, 4, 'list has 4 items');
+  assert.equal(post.sections.length, 1, "1 section");
+  assert.ok(post.sections.head.isListSection, "head section is list");
+  assert.equal(post.sections.head.items.length, 4, "list has 4 items");
 
   let text = post.sections.head.items.toArray().map(i => i.text);
-  assert.deepEqual(text, ['abc', 'def', 'ghi', '123']);
+  assert.deepEqual(text, ["abc", "def", "ghi", "123"]);
 
-  assert.ok(editor.range.head.section === post.sections.head.items.objectAt(1), 'selected head correct');
+  assert.ok(
+    editor.range.head.section === post.sections.head.items.objectAt(1),
+    "selected head correct"
+  );
   assert.equal(editor.range.head.offset, 0);
 });
 
-test('#toggleSection untoggle last list item changes it to markup section', (assert) => {
+test("#toggleSection untoggle last list item changes it to markup section", assert => {
   let post = Helpers.postAbstract.build(
-    ({post, listSection, listItem, marker}) => {
-    return post([listSection('ul', [
-      listItem([marker('abc')]),
-      listItem([marker('def')]),
-      listItem([marker('ghi')])
-    ])]);
-  });
+    ({ post, listSection, listItem, marker }) => {
+      return post([
+        listSection("ul", [
+          listItem([marker("abc")]),
+          listItem([marker("def")]),
+          listItem([marker("ghi")])
+        ])
+      ]);
+    }
+  );
   mockEditor = renderBuiltAbstract(post, mockEditor);
   let range = Range.create(post.sections.head.items.tail, 0);
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('ul', range);
+  postEditor.toggleSection("ul", range);
   postEditor.complete();
 
-  assert.equal(post.sections.length, 2, '2 sections');
-  assert.ok(post.sections.head.isListSection, 'head section is list');
-  assert.equal(post.sections.tail.tagName, 'p', 'tail is p');
-  assert.equal(post.sections.tail.text, 'ghi');
+  assert.equal(post.sections.length, 2, "2 sections");
+  assert.ok(post.sections.head.isListSection, "head section is list");
+  assert.equal(post.sections.tail.tagName, "p", "tail is p");
+  assert.equal(post.sections.tail.text, "ghi");
 
-  assert.equal(post.sections.head.items.length, 2, '2 items in list');
-  assert.equal(post.sections.head.items.head.text, 'abc');
-  assert.equal(post.sections.head.items.tail.text, 'def');
+  assert.equal(post.sections.head.items.length, 2, "2 items in list");
+  assert.equal(post.sections.head.items.head.text, "abc");
+  assert.equal(post.sections.head.items.tail.text, "def");
 
-  assert.positionIsEqual(mockEditor._renderedRange.head, post.sections.tail.headPosition());
+  assert.positionIsEqual(
+    mockEditor._renderedRange.head,
+    post.sections.tail.headPosition()
+  );
 });
 
-test('#toggleSection toggle list item to different type of list item', (assert) => {
+test("#toggleSection toggle list item to different type of list item", assert => {
   let post = Helpers.postAbstract.build(
-    ({post, listSection, listItem, marker}) => {
-    return post([listSection('ul', [listItem([marker('abc')])])]);
-  });
+    ({ post, listSection, listItem, marker }) => {
+      return post([listSection("ul", [listItem([marker("abc")])])]);
+    }
+  );
 
   let range = Range.create(post.sections.head.items.head, 0);
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('ol', range);
+  postEditor.toggleSection("ol", range);
   postEditor.complete();
 
-  assert.equal(post.sections.length, 1, '1 section');
-  assert.ok(post.sections.head.isListSection, 'section is list');
-  assert.equal(post.sections.head.tagName, 'ol', 'section is ol list');
-  assert.equal(post.sections.head.items.length, 1, '1 item');
-  assert.equal(post.sections.head.items.head.text, 'abc');
+  assert.equal(post.sections.length, 1, "1 section");
+  assert.ok(post.sections.head.isListSection, "section is list");
+  assert.equal(post.sections.head.tagName, "ol", "section is ol list");
+  assert.equal(post.sections.head.items.length, 1, "1 item");
+  assert.equal(post.sections.head.items.head.text, "abc");
 
-  assert.positionIsEqual(mockEditor._renderedRange.head, post.sections.head.items.head.headPosition());
+  assert.positionIsEqual(
+    mockEditor._renderedRange.head,
+    post.sections.head.items.head.headPosition()
+  );
 });
 
-test('#toggleSection toggle list item to different type of list item when other sections precede it', (assert) => {
+test("#toggleSection toggle list item to different type of list item when other sections precede it", assert => {
   let post = Helpers.postAbstract.build(
-    ({post, listSection, listItem, marker, markupSection}) => {
-    return post([
-      markupSection('p', [marker('123')]),
-      listSection('ul', [listItem([marker('abc')])])
-    ]);
-  });
+    ({ post, listSection, listItem, marker, markupSection }) => {
+      return post([
+        markupSection("p", [marker("123")]),
+        listSection("ul", [listItem([marker("abc")])])
+      ]);
+    }
+  );
 
   let range = Range.create(post.sections.tail.items.head, 0);
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('ol', range);
+  postEditor.toggleSection("ol", range);
   postEditor.complete();
 
-  assert.equal(post.sections.length, 2, '2 section');
-  assert.equal(post.sections.head.tagName, 'p', '1st section is p');
-  assert.equal(post.sections.head.text, '123');
-  assert.ok(post.sections.tail.isListSection, 'section is list');
-  assert.equal(post.sections.tail.tagName, 'ol', 'section is ol list');
-  assert.equal(post.sections.tail.items.length, 1, '1 item');
-  assert.equal(post.sections.tail.items.head.text, 'abc');
+  assert.equal(post.sections.length, 2, "2 section");
+  assert.equal(post.sections.head.tagName, "p", "1st section is p");
+  assert.equal(post.sections.head.text, "123");
+  assert.ok(post.sections.tail.isListSection, "section is list");
+  assert.equal(post.sections.tail.tagName, "ol", "section is ol list");
+  assert.equal(post.sections.tail.items.length, 1, "1 item");
+  assert.equal(post.sections.tail.items.head.text, "abc");
 
-  assert.positionIsEqual(mockEditor._renderedRange.head, post.sections.tail.items.head.headPosition());
+  assert.positionIsEqual(
+    mockEditor._renderedRange.head,
+    post.sections.tail.items.head.headPosition()
+  );
 });
 
-test('#toggleSection toggle when cursor on card section is no-op', (assert) => {
-  let post = Helpers.postAbstract.build(
-    ({post, cardSection}) => {
-    return post([cardSection('my-card')]);
+test("#toggleSection toggle when cursor on card section is no-op", assert => {
+  let post = Helpers.postAbstract.build(({ post, cardSection }) => {
+    return post([cardSection("my-card")]);
   });
 
   let range = Range.create(post.sections.head, 0);
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('ol', range);
+  postEditor.toggleSection("ol", range);
   postEditor.complete();
 
-  assert.equal(post.sections.length, 1, '1 section');
-  assert.ok(post.sections.head.isCardSection, 'still card section');
+  assert.equal(post.sections.length, 1, "1 section");
+  assert.ok(post.sections.head.isCardSection, "still card section");
 
-  assert.positionIsEqual(mockEditor._renderedRange.head, range.head, 'range head is set to same');
-  assert.positionIsEqual(mockEditor._renderedRange.tail, range.tail, 'range tail is set to same');
+  assert.positionIsEqual(
+    mockEditor._renderedRange.head,
+    range.head,
+    "range head is set to same"
+  );
+  assert.positionIsEqual(
+    mockEditor._renderedRange.tail,
+    range.tail,
+    "range tail is set to same"
+  );
 });
 
-test('#toggleSection joins contiguous list items', (assert) => {
+test("#toggleSection joins contiguous list items", assert => {
   let mobiledoc = Helpers.mobiledoc.build(
-    ({post, listSection, listItem, marker}) => {
-    return post([
-      listSection('ul', [listItem([marker('abc')])]),
-      listSection('ol', [listItem([marker('123')])]),
-      listSection('ul', [listItem([marker('def')])])
-    ]);
-  });
+    ({ post, listSection, listItem, marker }) => {
+      return post([
+        listSection("ul", [listItem([marker("abc")])]),
+        listSection("ol", [listItem([marker("123")])]),
+        listSection("ul", [listItem([marker("def")])])
+      ]);
+    }
+  );
 
-  editor = new Editor({mobiledoc});
+  editor = new Editor({ mobiledoc });
   editor.render(editorElement);
   let { post } = editor;
   let range = Range.create(post.sections.objectAt(1).items.head, 0);
   postEditor = new PostEditor(editor);
-  postEditor.toggleSection('ul', range);
+  postEditor.toggleSection("ul", range);
   postEditor.complete();
 
-  assert.equal(post.sections.length, 1, '1 section');
-  assert.ok(post.sections.head.isListSection, 'is list');
-  assert.equal(post.sections.head.items.length, 3, '3 items');
-  assert.deepEqual(post.sections.head.items.map(i => i.text),
-                   ['abc', '123', 'def']);
+  assert.equal(post.sections.length, 1, "1 section");
+  assert.ok(post.sections.head.isListSection, "is list");
+  assert.equal(post.sections.head.items.length, 3, "3 items");
+  assert.deepEqual(
+    post.sections.head.items.map(i => i.text),
+    ["abc", "123", "def"]
+  );
 });
 
-test('#toggleSection maintains the selection when the sections in the selected range are still there', (assert) => {
-  let post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
-    return post([
-      markupSection('p', [marker('abc')])
-    ]);
+test("#toggleSection maintains the selection when the sections in the selected range are still there", assert => {
+  let post = Helpers.postAbstract.build(({ post, markupSection, marker }) => {
+    return post([markupSection("p", [marker("abc")])]);
   });
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
-  const range = Range.create(post.sections.head, 1,
-                             post.sections.head, 2);
+  const range = Range.create(post.sections.head, 1, post.sections.head, 2);
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.toggleSection('h1', range);
+  postEditor.toggleSection("h1", range);
   postEditor.complete();
 
   assert.positionIsEqual(
     mockEditor._renderedRange.head,
     post.sections.head.toPosition(1),
-    'Maintains the selection'
+    "Maintains the selection"
   );
   assert.positionIsEqual(
     mockEditor._renderedRange.tail,
     post.sections.tail.toPosition(2),
-    'Maintains the selection'
+    "Maintains the selection"
   );
 });
 
-test('#toggleMarkup when cursor is in non-markerable does nothing', (assert) => {
+test("#toggleMarkup when cursor is in non-markerable does nothing", assert => {
   editor = buildEditorWithMobiledoc(
-    ({post, markupSection, marker, cardSection}) => {
-    return post([
-      cardSection('my-card')
-    ]);
-  });
+    ({ post, markupSection, marker, cardSection }) => {
+      return post([cardSection("my-card")]);
+    }
+  );
 
   const range = editor.post.sections.head.headPosition().toRange();
   postEditor = new PostEditor(editor);
-  postEditor.toggleMarkup('b', range);
+  postEditor.toggleMarkup("b", range);
   postEditor.complete();
 
   assert.ok(editor.post.sections.head.isCardSection);
-  assert.positionIsEqual(editor._renderedRange.head,
-                         editor.post.sections.head.headPosition());
+  assert.positionIsEqual(
+    editor._renderedRange.head,
+    editor.post.sections.head.headPosition()
+  );
 });
 
-test('#toggleMarkup when cursor surrounds non-markerable does nothing', (assert) => {
+test("#toggleMarkup when cursor surrounds non-markerable does nothing", assert => {
   editor = buildEditorWithMobiledoc(
-    ({post, markupSection, marker, cardSection}) => {
-    return post([
-      cardSection('my-card')
-    ]);
-  });
+    ({ post, markupSection, marker, cardSection }) => {
+      return post([cardSection("my-card")]);
+    }
+  );
 
   const range = editor.post.sections.head.toRange();
   postEditor = new PostEditor(editor);
-  postEditor.toggleMarkup('b', range);
+  postEditor.toggleMarkup("b", range);
   postEditor.complete();
 
   assert.ok(editor.post.sections.head.isCardSection);
-  assert.positionIsEqual(editor._renderedRange.head,
-                         editor.post.sections.head.headPosition());
+  assert.positionIsEqual(
+    editor._renderedRange.head,
+    editor.post.sections.head.headPosition()
+  );
 });
 
-test('#toggleMarkup when range has the markup removes it', (assert) => {
+test("#toggleMarkup when range has the markup removes it", assert => {
   editor = buildEditorWithMobiledoc(
-    ({post, markupSection, marker, markup}) => {
-    return post([markupSection('p', [marker('abc', [markup('b')])])]);
-  });
+    ({ post, markupSection, marker, markup }) => {
+      return post([markupSection("p", [marker("abc", [markup("b")])])]);
+    }
+  );
   let expected = Helpers.postAbstract.build(
-    ({post, markupSection, marker}) => {
-    return post([markupSection('p', [marker('abc')])]);
-  });
+    ({ post, markupSection, marker }) => {
+      return post([markupSection("p", [marker("abc")])]);
+    }
+  );
 
   const range = editor.post.sections.head.toRange();
   postEditor = new PostEditor(editor);
-  postEditor.toggleMarkup('b', range);
+  postEditor.toggleMarkup("b", range);
   postEditor.complete();
 
-  assert.positionIsEqual(editor._renderedRange.head, editor.post.headPosition());
-  assert.positionIsEqual(editor._renderedRange.tail, editor.post.tailPosition());
+  assert.positionIsEqual(
+    editor._renderedRange.head,
+    editor.post.headPosition()
+  );
+  assert.positionIsEqual(
+    editor._renderedRange.tail,
+    editor.post.tailPosition()
+  );
   assert.postIsSimilar(editor.post, expected);
 });
 
-test('#toggleMarkup when only some of the range has it removes it', (assert) => {
+test("#toggleMarkup when only some of the range has it removes it", assert => {
   editor = buildEditorWithMobiledoc(
-    ({post, markupSection, marker, markup}) => {
-    return post([markupSection('p', [
-      marker('a'),
-      marker('b', [markup('b')]),
-      marker('c')
-    ])]);
-  });
+    ({ post, markupSection, marker, markup }) => {
+      return post([
+        markupSection("p", [
+          marker("a"),
+          marker("b", [markup("b")]),
+          marker("c")
+        ])
+      ]);
+    }
+  );
   let expected = Helpers.postAbstract.build(
-    ({post, markupSection, marker}) => {
-    return post([markupSection('p', [marker('abc')])]);
-  });
+    ({ post, markupSection, marker }) => {
+      return post([markupSection("p", [marker("abc")])]);
+    }
+  );
 
   const range = editor.post.sections.head.toRange();
   postEditor = new PostEditor(editor);
-  postEditor.toggleMarkup('b', range);
+  postEditor.toggleMarkup("b", range);
   postEditor.complete();
 
-  assert.positionIsEqual(editor._renderedRange.head,
-                         editor.post.sections.head.headPosition());
-  assert.positionIsEqual(editor._renderedRange.tail,
-                         editor.post.sections.head.tailPosition());
+  assert.positionIsEqual(
+    editor._renderedRange.head,
+    editor.post.sections.head.headPosition()
+  );
+  assert.positionIsEqual(
+    editor._renderedRange.tail,
+    editor.post.sections.head.tailPosition()
+  );
   assert.postIsSimilar(editor.post, expected);
 });
 
-test('#toggleMarkup when range does not have the markup adds it', (assert) => {
-  editor = buildEditorWithMobiledoc(
-    ({post, markupSection, marker}) => {
-    return post([markupSection('p', [marker('abc')])]);
+test("#toggleMarkup when range does not have the markup adds it", assert => {
+  editor = buildEditorWithMobiledoc(({ post, markupSection, marker }) => {
+    return post([markupSection("p", [marker("abc")])]);
   });
   let expected = Helpers.postAbstract.build(
-    ({post, markupSection, marker, markup}) => {
-    return post([markupSection('p', [marker('abc', [markup('b')])])]);
-  });
+    ({ post, markupSection, marker, markup }) => {
+      return post([markupSection("p", [marker("abc", [markup("b")])])]);
+    }
+  );
 
   const range = editor.post.sections.head.toRange();
   postEditor = new PostEditor(editor);
-  postEditor.toggleMarkup('b', range);
+  postEditor.toggleMarkup("b", range);
   postEditor.complete();
 
-  assert.positionIsEqual(editor._renderedRange.head,
-                         editor.post.sections.head.headPosition());
-  assert.positionIsEqual(editor._renderedRange.tail,
-                         editor.post.sections.head.tailPosition());
+  assert.positionIsEqual(
+    editor._renderedRange.head,
+    editor.post.sections.head.headPosition()
+  );
+  assert.positionIsEqual(
+    editor._renderedRange.tail,
+    editor.post.sections.head.tailPosition()
+  );
   assert.postIsSimilar(editor.post, expected);
 });
 
-test('#toggleMarkup when the editor has no cursor', (assert) => {
+test("#toggleMarkup when the editor has no cursor", assert => {
   let done = assert.async();
 
-  editor = buildEditorWithMobiledoc(
-    ({post, markupSection, marker}) => {
-    return post([markupSection('p', [marker('abc')])]);
+  editor = buildEditorWithMobiledoc(({ post, markupSection, marker }) => {
+    return post([markupSection("p", [marker("abc")])]);
   }, false);
   let expected = Helpers.postAbstract.build(
-    ({post, markupSection, marker}) => {
-    return post([markupSection('p', [marker('abc')])]);
-  });
+    ({ post, markupSection, marker }) => {
+      return post([markupSection("p", [marker("abc")])]);
+    }
+  );
 
   editor._renderedRange = null;
-  editor.run(postEditor => postEditor.toggleMarkup('b'));
+  editor.run(postEditor => postEditor.toggleMarkup("b"));
 
   Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected);
-    assert.equal(window.getSelection().rangeCount, 0,
-                 'nothing is selected');
-    assert.ok(document.activeElement !== editorElement,
-              'active element is not editor element');
-    assert.ok(editor._renderedRange && editor._renderedRange.isBlank, 'rendered range is blank');
+    assert.equal(window.getSelection().rangeCount, 0, "nothing is selected");
+    assert.ok(
+      document.activeElement !== editorElement,
+      "active element is not editor element"
+    );
+    assert.ok(
+      editor._renderedRange && editor._renderedRange.isBlank,
+      "rendered range is blank"
+    );
 
     done();
   });
 });
 
-test('#insertMarkers inserts an atom', (assert) => {
+test("#insertMarkers inserts an atom", assert => {
   let toInsert, expected;
-  Helpers.postAbstract.build(({post, markupSection, marker, markup, atom}) => {
-    toInsert = [
-      atom('simple-atom', '123', [markup('b')])
-    ];
-    expected = post([
-      markupSection('p', [
-        marker('abc'),
-        atom('simple-atom', '123', [markup('b')]),
-        marker('def')
-    ])]);
-  });
+  Helpers.postAbstract.build(
+    ({ post, markupSection, marker, markup, atom }) => {
+      toInsert = [atom("simple-atom", "123", [markup("b")])];
+      expected = post([
+        markupSection("p", [
+          marker("abc"),
+          atom("simple-atom", "123", [markup("b")]),
+          marker("def")
+        ])
+      ]);
+    }
+  );
 
-  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
-    return post([markupSection('p', [marker('abcdef')])]);
+  editor = buildEditorWithMobiledoc(({ post, markupSection, marker }) => {
+    return post([markupSection("p", [marker("abcdef")])]);
   });
-  let position = editor.post.sections.head.toPosition('abc'.length);
+  let position = editor.post.sections.head.toPosition("abc".length);
   postEditor = new PostEditor(editor);
   postEditor.insertMarkers(position, toInsert);
   postEditor.complete();
@@ -1552,24 +1768,23 @@ test('#insertMarkers inserts an atom', (assert) => {
   );
 });
 
-test('#insertMarkers inserts the markers in middle, merging markups', (assert) => {
+test("#insertMarkers inserts the markers in middle, merging markups", assert => {
   let toInsert, expected;
-  Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
-    toInsert = [
-      marker('123', [markup('b')]), marker('456')
-    ];
+  Helpers.postAbstract.build(({ post, markupSection, marker, markup }) => {
+    toInsert = [marker("123", [markup("b")]), marker("456")];
     expected = post([
-      markupSection('p', [
-        marker('abc'),
-        marker('123', [markup('b')]),
-        marker('456def')
-    ])]);
+      markupSection("p", [
+        marker("abc"),
+        marker("123", [markup("b")]),
+        marker("456def")
+      ])
+    ]);
   });
 
-  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
-    return post([markupSection('p', [marker('abcdef')])]);
+  editor = buildEditorWithMobiledoc(({ post, markupSection, marker }) => {
+    return post([markupSection("p", [marker("abcdef")])]);
   });
-  let position = editor.post.sections.head.toPosition('abc'.length);
+  let position = editor.post.sections.head.toPosition("abc".length);
   postEditor = new PostEditor(editor);
   postEditor.insertMarkers(position, toInsert);
   postEditor.complete();
@@ -1578,24 +1793,20 @@ test('#insertMarkers inserts the markers in middle, merging markups', (assert) =
   assert.renderTreeIsEqual(editor._renderTree, expected);
   assert.positionIsEqual(
     editor._renderedRange.head,
-    editor.post.sections.head.toPosition('abc123456'.length)
+    editor.post.sections.head.toPosition("abc123456".length)
   );
 });
 
-test('#insertMarkers inserts the markers when the markerable has no markers', (assert) => {
+test("#insertMarkers inserts the markers when the markerable has no markers", assert => {
   let toInsert, expected;
-  Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
-    toInsert = [
-      marker('123', [markup('b')]), marker('456')
-    ];
+  Helpers.postAbstract.build(({ post, markupSection, marker, markup }) => {
+    toInsert = [marker("123", [markup("b")]), marker("456")];
     expected = post([
-      markupSection('p', [
-        marker('123', [markup('b')]),
-        marker('456')
-    ])]);
+      markupSection("p", [marker("123", [markup("b")]), marker("456")])
+    ]);
   });
 
-  editor = buildEditorWithMobiledoc(({post, markupSection}) => {
+  editor = buildEditorWithMobiledoc(({ post, markupSection }) => {
     return post([markupSection()]);
   });
   let position = editor.post.sections.head.headPosition();
@@ -1607,25 +1818,21 @@ test('#insertMarkers inserts the markers when the markerable has no markers', (a
   assert.renderTreeIsEqual(editor._renderTree, expected);
   assert.positionIsEqual(
     editor._renderedRange.head,
-    editor.post.sections.head.toPosition('123456'.length)
+    editor.post.sections.head.toPosition("123456".length)
   );
 });
 
-test('#insertMarkers inserts the markers at start', (assert) => {
+test("#insertMarkers inserts the markers at start", assert => {
   let toInsert, expected;
-  Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
-    toInsert = [
-      marker('123', [markup('b')]), marker('456')
-    ];
+  Helpers.postAbstract.build(({ post, markupSection, marker, markup }) => {
+    toInsert = [marker("123", [markup("b")]), marker("456")];
     expected = post([
-      markupSection('p', [
-        marker('123', [markup('b')]),
-        marker('456abc')
-    ])]);
+      markupSection("p", [marker("123", [markup("b")]), marker("456abc")])
+    ]);
   });
 
-  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
-    return post([markupSection('p', [marker('abc')])]);
+  editor = buildEditorWithMobiledoc(({ post, markupSection, marker }) => {
+    return post([markupSection("p", [marker("abc")])]);
   });
   let position = editor.post.sections.head.headPosition();
   postEditor = new PostEditor(editor);
@@ -1636,26 +1843,25 @@ test('#insertMarkers inserts the markers at start', (assert) => {
   assert.renderTreeIsEqual(editor._renderTree, expected);
   assert.positionIsEqual(
     editor._renderedRange.head,
-    editor.post.sections.head.toPosition('123456'.length)
+    editor.post.sections.head.toPosition("123456".length)
   );
 });
 
-test('#insertMarkers inserts the markers at end', (assert) => {
+test("#insertMarkers inserts the markers at end", assert => {
   let toInsert, expected;
-  Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
-    toInsert = [
-      marker('123', [markup('b')]), marker('456')
-    ];
+  Helpers.postAbstract.build(({ post, markupSection, marker, markup }) => {
+    toInsert = [marker("123", [markup("b")]), marker("456")];
     expected = post([
-      markupSection('p', [
-        marker('abc'),
-        marker('123', [markup('b')]),
-        marker('456')
-    ])]);
+      markupSection("p", [
+        marker("abc"),
+        marker("123", [markup("b")]),
+        marker("456")
+      ])
+    ]);
   });
 
-  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
-    return post([markupSection('p', [marker('abc')])]);
+  editor = buildEditorWithMobiledoc(({ post, markupSection, marker }) => {
+    return post([markupSection("p", [marker("abc")])]);
   });
   let position = editor.post.sections.head.tailPosition();
   postEditor = new PostEditor(editor);
@@ -1670,14 +1876,14 @@ test('#insertMarkers inserts the markers at end', (assert) => {
   );
 });
 
-test('#insertMarkers throws if the position is not markerable', (assert) => {
+test("#insertMarkers throws if the position is not markerable", assert => {
   let toInsert;
-  Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
-    toInsert = [marker('123', [markup('b')]), marker('456')];
+  Helpers.postAbstract.build(({ post, markupSection, marker, markup }) => {
+    toInsert = [marker("123", [markup("b")]), marker("456")];
   });
 
-  editor = buildEditorWithMobiledoc(({post, cardSection}) => {
-    return post([cardSection('some-card')]);
+  editor = buildEditorWithMobiledoc(({ post, cardSection }) => {
+    return post([cardSection("some-card")]);
   });
   let position = editor.post.sections.head.tailPosition();
   postEditor = new PostEditor(editor);
@@ -1687,13 +1893,13 @@ test('#insertMarkers throws if the position is not markerable', (assert) => {
   }, /cannot insert.*non-markerable/i);
 });
 
-test('#insertText is no-op if the position section is not markerable', (assert) => {
-  let toInsert = '123';
-  let expected = Helpers.postAbstract.build(({post, cardSection}) => {
-    return post([cardSection('test-card')]);
+test("#insertText is no-op if the position section is not markerable", assert => {
+  let toInsert = "123";
+  let expected = Helpers.postAbstract.build(({ post, cardSection }) => {
+    return post([cardSection("test-card")]);
   });
-  editor = buildEditorWithMobiledoc(({post, cardSection}) => {
-    return post([cardSection('test-card')]);
+  editor = buildEditorWithMobiledoc(({ post, cardSection }) => {
+    return post([cardSection("test-card")]);
   });
   let position = editor.post.sections.head.headPosition();
   postEditor = new PostEditor(editor);
@@ -1702,22 +1908,24 @@ test('#insertText is no-op if the position section is not markerable', (assert) 
 
   assert.postIsSimilar(editor.post, expected);
   assert.renderTreeIsEqual(editor._renderTree, expected);
-  assert.ok(!editor._renderedRange, 'no range is rendered since nothing happened');
+  assert.ok(
+    !editor._renderedRange,
+    "no range is rendered since nothing happened"
+  );
 });
 
-test('#insertText inserts the text at start', (assert) => {
+test("#insertText inserts the text at start", assert => {
   let toInsert, expected;
-  Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
-    toInsert = '123';
-    expected = post([
-      markupSection('p', [
-        marker('123abc', [markup('b')])
-    ])]);
+  Helpers.postAbstract.build(({ post, markupSection, marker, markup }) => {
+    toInsert = "123";
+    expected = post([markupSection("p", [marker("123abc", [markup("b")])])]);
   });
 
-  editor = buildEditorWithMobiledoc(({post, markupSection, marker, markup}) => {
-    return post([markupSection('p', [marker('abc', [markup('b')])])]);
-  });
+  editor = buildEditorWithMobiledoc(
+    ({ post, markupSection, marker, markup }) => {
+      return post([markupSection("p", [marker("abc", [markup("b")])])]);
+    }
+  );
   let position = editor.post.sections.head.headPosition();
   postEditor = new PostEditor(editor);
   postEditor.insertText(position, toInsert);
@@ -1727,24 +1935,23 @@ test('#insertText inserts the text at start', (assert) => {
   assert.renderTreeIsEqual(editor._renderTree, expected);
   assert.positionIsEqual(
     editor._renderedRange.head,
-    editor.post.sections.head.toPosition('123'.length)
+    editor.post.sections.head.toPosition("123".length)
   );
 });
 
-test('#insertText inserts text in the middle', (assert) => {
+test("#insertText inserts text in the middle", assert => {
   let toInsert, expected;
-  Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
-    toInsert = '123';
-    expected = post([
-      markupSection('p', [
-        marker('ab123c', [markup('b')])
-    ])]);
+  Helpers.postAbstract.build(({ post, markupSection, marker, markup }) => {
+    toInsert = "123";
+    expected = post([markupSection("p", [marker("ab123c", [markup("b")])])]);
   });
 
-  editor = buildEditorWithMobiledoc(({post, markupSection, marker, markup}) => {
-    return post([markupSection('p', [marker('abc', [markup('b')])])]);
-  });
-  let position = editor.post.sections.head.toPosition('ab'.length);
+  editor = buildEditorWithMobiledoc(
+    ({ post, markupSection, marker, markup }) => {
+      return post([markupSection("p", [marker("abc", [markup("b")])])]);
+    }
+  );
+  let position = editor.post.sections.head.toPosition("ab".length);
   postEditor = new PostEditor(editor);
   postEditor.insertText(position, toInsert);
   postEditor.complete();
@@ -1753,23 +1960,22 @@ test('#insertText inserts text in the middle', (assert) => {
   assert.renderTreeIsEqual(editor._renderTree, expected);
   assert.positionIsEqual(
     editor._renderedRange.head,
-    editor.post.sections.head.toPosition('ab123'.length)
+    editor.post.sections.head.toPosition("ab123".length)
   );
 });
 
-test('#insertText inserts text at the end', (assert) => {
+test("#insertText inserts text at the end", assert => {
   let toInsert, expected;
-  Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
-    toInsert = '123';
-    expected = post([
-      markupSection('p', [
-        marker('abc123', [markup('b')])
-    ])]);
+  Helpers.postAbstract.build(({ post, markupSection, marker, markup }) => {
+    toInsert = "123";
+    expected = post([markupSection("p", [marker("abc123", [markup("b")])])]);
   });
 
-  editor = buildEditorWithMobiledoc(({post, markupSection, marker, markup}) => {
-    return post([markupSection('p', [marker('abc', [markup('b')])])]);
-  });
+  editor = buildEditorWithMobiledoc(
+    ({ post, markupSection, marker, markup }) => {
+      return post([markupSection("p", [marker("abc", [markup("b")])])]);
+    }
+  );
   let position = editor.post.sections.head.tailPosition();
   postEditor = new PostEditor(editor);
   postEditor.insertText(position, toInsert);
@@ -1783,23 +1989,29 @@ test('#insertText inserts text at the end', (assert) => {
   );
 });
 
-test('#_splitListItem creates two list items', (assert) => {
+test("#_splitListItem creates two list items", assert => {
   let expected = Helpers.postAbstract.build(
-    ({post, listSection, listItem, marker, markup}) => {
-    return post([listSection('ul', [
-      listItem([marker('abc'), marker('bo', [markup('b')])]),
-      listItem([marker('ld', [markup('b')])])
-    ])]);
-  });
+    ({ post, listSection, listItem, marker, markup }) => {
+      return post([
+        listSection("ul", [
+          listItem([marker("abc"), marker("bo", [markup("b")])]),
+          listItem([marker("ld", [markup("b")])])
+        ])
+      ]);
+    }
+  );
   editor = buildEditorWithMobiledoc(
-    ({post, listSection, listItem, marker, markup}) => {
-    return post([listSection('ul', [
-      listItem([marker('abc'), marker('bold', [markup('b')])])
-    ])]);
-  });
+    ({ post, listSection, listItem, marker, markup }) => {
+      return post([
+        listSection("ul", [
+          listItem([marker("abc"), marker("bold", [markup("b")])])
+        ])
+      ]);
+    }
+  );
 
   let item = editor.post.sections.head.items.head;
-  let position = item.toPosition('abcbo'.length);
+  let position = item.toPosition("abcbo".length);
   postEditor = new PostEditor(editor);
   postEditor._splitListItem(item, position);
   postEditor.complete();
@@ -1808,18 +2020,19 @@ test('#_splitListItem creates two list items', (assert) => {
   assert.renderTreeIsEqual(editor._renderTree, expected);
 });
 
-test('#_splitListItem when position is start creates blank list item', (assert) => {
+test("#_splitListItem when position is start creates blank list item", assert => {
   let expected = Helpers.postAbstract.build(
-    ({post, listSection, listItem, marker}) => {
-    return post([listSection('ul', [
-      listItem([marker('')]),
-      listItem([marker('abc')])
-    ])]);
-  });
+    ({ post, listSection, listItem, marker }) => {
+      return post([
+        listSection("ul", [listItem([marker("")]), listItem([marker("abc")])])
+      ]);
+    }
+  );
   editor = buildEditorWithMobiledoc(
-    ({post, listSection, listItem, marker}) => {
-    return post([listSection('ul', [listItem([marker('abc')])])]);
-  });
+    ({ post, listSection, listItem, marker }) => {
+      return post([listSection("ul", [listItem([marker("abc")])])]);
+    }
+  );
 
   let item = editor.post.sections.head.items.head;
   let position = item.headPosition();

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -1,16 +1,16 @@
-import Helpers from '../../test-helpers';
-import Range from 'mobiledoc-kit/utils/cursor/range';
-import Position from 'mobiledoc-kit/utils/cursor/position';
+import Helpers from "../../test-helpers";
+import Range from "mobiledoc-kit/utils/cursor/range";
+import Position from "mobiledoc-kit/utils/cursor/position";
 
-const {module, test} = Helpers;
+const { module, test } = Helpers;
 
-module('Unit: Post');
+module("Unit: Post");
 
-test('#walkMarkerableSections finds no section when range contains only a card', (assert) => {
+test("#walkMarkerableSections finds no section when range contains only a card", assert => {
   const post = Helpers.postAbstract.build(builder => {
-    const {post, cardSection} = builder;
+    const { post, cardSection } = builder;
 
-    return post([cardSection('simple-card')]);
+    return post([cardSection("simple-card")]);
   });
 
   let foundSections = [];
@@ -19,19 +19,31 @@ test('#walkMarkerableSections finds no section when range contains only a card',
   const range = Range.create(card, 0, card, 0);
 
   post.walkMarkerableSections(range, s => foundSections.push(s));
-  assert.equal(foundSections.length, 0, 'found no markerable sections');
+  assert.equal(foundSections.length, 0, "found no markerable sections");
 });
 
-test('#walkMarkerableSections skips non-markerable sections', (assert) => {
+test("#walkMarkerableSections skips non-markerable sections", assert => {
   const post = Helpers.postAbstract.build(builder => {
-    const {post, markupSection, marker, cardSection} = builder;
+    const { post, markupSection, marker, cardSection } = builder;
 
     return post([
-      markupSection('p', ['s1m1'].map(t => marker(t))),
-      markupSection('p', ['s2m1'].map(t => marker(t))),
-      cardSection('simple-card'),
-      markupSection('p', ['s3m1'].map(t => marker(t))),
-      markupSection('p', ['s4m1'].map(t => marker(t)))
+      markupSection(
+        "p",
+        ["s1m1"].map(t => marker(t))
+      ),
+      markupSection(
+        "p",
+        ["s2m1"].map(t => marker(t))
+      ),
+      cardSection("simple-card"),
+      markupSection(
+        "p",
+        ["s3m1"].map(t => marker(t))
+      ),
+      markupSection(
+        "p",
+        ["s4m1"].map(t => marker(t))
+      )
     ]);
   });
 
@@ -40,254 +52,308 @@ test('#walkMarkerableSections skips non-markerable sections', (assert) => {
   const s1 = post.sections.objectAt(0);
   const s4 = post.sections.objectAt(4);
 
-  assert.equal(s1.text, 's1m1', 'precond - find s1');
-  assert.equal(s4.text, 's4m1', 'precond - find s4');
+  assert.equal(s1.text, "s1m1", "precond - find s1");
+  assert.equal(s4.text, "s4m1", "precond - find s4");
 
   const range = Range.create(s1, 0, s4, 0);
 
   post.walkMarkerableSections(range, s => foundSections.push(s));
 
-  assert.deepEqual(foundSections.map(s => s.text),
-                   ['s1m1', 's2m1', 's3m1', 's4m1'],
-                   'iterates correct sections');
-
+  assert.deepEqual(
+    foundSections.map(s => s.text),
+    ["s1m1", "s2m1", "s3m1", "s4m1"],
+    "iterates correct sections"
+  );
 });
 
-test('#walkAllLeafSections returns markup section that follows a list section', (assert) => {
-  let post = Helpers.postAbstract.build(({post, markupSection, marker, listSection, listItem}) => {
-    return post([
-      markupSection('p', [marker('abc')]),
-      markupSection('p', [marker('def')]),
-      listSection('ul', [
-        listItem([marker('123')])
-      ]),
-      markupSection('p')
-    ]);
-  });
+test("#walkAllLeafSections returns markup section that follows a list section", assert => {
+  let post = Helpers.postAbstract.build(
+    ({ post, markupSection, marker, listSection, listItem }) => {
+      return post([
+        markupSection("p", [marker("abc")]),
+        markupSection("p", [marker("def")]),
+        listSection("ul", [listItem([marker("123")])]),
+        markupSection("p")
+      ]);
+    }
+  );
 
   let sections = [];
   post.walkAllLeafSections(s => sections.push(s));
 
   assert.equal(sections.length, 4);
-  assert.ok(sections[0] === post.sections.head, 'section 0');
-  assert.ok(sections[1] === post.sections.objectAt(1), 'section 1');
-  assert.ok(sections[2] === post.sections.objectAt(2).items.head, 'section 2');
-  assert.ok(sections[3] === post.sections.tail, 'section 3');
+  assert.ok(sections[0] === post.sections.head, "section 0");
+  assert.ok(sections[1] === post.sections.objectAt(1), "section 1");
+  assert.ok(sections[2] === post.sections.objectAt(2).items.head, "section 2");
+  assert.ok(sections[3] === post.sections.tail, "section 3");
 });
 
-test('#markupsInRange returns all markups when range is not collapsed', (assert) => {
+test("#markupsInRange returns all markups when range is not collapsed", assert => {
   let b, i, a1, a2, found, collapsedRange;
   const post = Helpers.postAbstract.build(builder => {
-    const {post, markupSection, cardSection, marker, markup} = builder;
+    const { post, markupSection, cardSection, marker, markup } = builder;
 
-    b  = markup('strong');
-    i  = markup('em');
-    a1 = markup('a', {href:'example.com'});
-    a2 = markup('a', {href:'other-example.com'});
+    b = markup("strong");
+    i = markup("em");
+    a1 = markup("a", { href: "example.com" });
+    a2 = markup("a", { href: "other-example.com" });
 
     return post([
-      markupSection('p', [
-        marker('plain text'),
-        marker('bold text', [b]),
-        marker('i text', [i]),
-        marker('bold+i text', [b, i])
+      markupSection("p", [
+        marker("plain text"),
+        marker("bold text", [b]),
+        marker("i text", [i]),
+        marker("bold+i text", [b, i])
       ]),
-      markupSection('p', [
-        marker('link 1', [a1])
-      ]),
-      cardSection('simple-card'),
-      markupSection('p', [
-        marker('link 2', [a2])
-      ])
+      markupSection("p", [marker("link 1", [a1])]),
+      cardSection("simple-card"),
+      markupSection("p", [marker("link 2", [a2])])
     ]);
   });
 
-  const [s1, s2,, s3] = post.sections.toArray();
+  const [s1, s2, , s3] = post.sections.toArray();
 
-  assert.equal(s1.text, 'plain textbold texti textbold+i text', 'precond s1');
-  assert.equal(s2.text, 'link 1', 'precond s2');
-  assert.equal(s3.text, 'link 2', 'precond s3');
+  assert.equal(s1.text, "plain textbold texti textbold+i text", "precond s1");
+  assert.equal(s2.text, "link 1", "precond s2");
+  assert.equal(s3.text, "link 2", "precond s3");
 
   collapsedRange = Range.create(s1, 0);
-  assert.equal(post.markupsInRange(collapsedRange).length, 0,
-               'no markups in collapsed range at start');
+  assert.equal(
+    post.markupsInRange(collapsedRange).length,
+    0,
+    "no markups in collapsed range at start"
+  );
 
-  collapsedRange = Range.create(s1, 'plain text'.length);
-  assert.equal(post.markupsInRange(collapsedRange).length, 0,
-               'no markups in collapsed range at end of plain text');
+  collapsedRange = Range.create(s1, "plain text".length);
+  assert.equal(
+    post.markupsInRange(collapsedRange).length,
+    0,
+    "no markups in collapsed range at end of plain text"
+  );
 
-  collapsedRange = Range.create(s1, 'plain textbold'.length);
+  collapsedRange = Range.create(s1, "plain textbold".length);
   found = post.markupsInRange(collapsedRange);
-  assert.equal(found.length, 1, 'markup in collapsed range in bold text');
-  assert.inArray(b, found, 'finds b in bold text');
+  assert.equal(found.length, 1, "markup in collapsed range in bold text");
+  assert.inArray(b, found, "finds b in bold text");
 
-  collapsedRange = Range.create(s1, 'plain textbold text'.length);
+  collapsedRange = Range.create(s1, "plain textbold text".length);
   found = post.markupsInRange(collapsedRange);
-  assert.equal(found.length, 1, 'markup in collapsed range at end of bold text');
-  assert.inArray(b, found, 'finds b at end of bold text');
+  assert.equal(
+    found.length,
+    1,
+    "markup in collapsed range at end of bold text"
+  );
+  assert.inArray(b, found, "finds b at end of bold text");
 
-  const simpleRange = Range.create(s1, 0, s1, 'plain text'.length);
-  assert.equal(post.markupsInRange(simpleRange).length, 0,
-               'no markups in simple range');
+  const simpleRange = Range.create(s1, 0, s1, "plain text".length);
+  assert.equal(
+    post.markupsInRange(simpleRange).length,
+    0,
+    "no markups in simple range"
+  );
 
-  const singleMarkerRange = Range.create(s1, 'plain textb'.length,
-                                      s1, 'plain textbold'.length);
+  const singleMarkerRange = Range.create(
+    s1,
+    "plain textb".length,
+    s1,
+    "plain textbold".length
+  );
   found = post.markupsInRange(singleMarkerRange);
-  assert.equal(found.length, 1, 'finds markup in marker');
-  assert.inArray(b, found, 'finds b');
+  assert.equal(found.length, 1, "finds markup in marker");
+  assert.inArray(b, found, "finds b");
 
   const singleSectionRange = Range.create(s1, 0, s1, s1.length);
   found = post.markupsInRange(singleSectionRange);
-  assert.equal(found.length, 2, 'finds both markups in section');
-  assert.inArray(b, found, 'finds b');
-  assert.inArray(i, found, 'finds i');
+  assert.equal(found.length, 2, "finds both markups in section");
+  assert.inArray(b, found, "finds b");
+  assert.inArray(i, found, "finds i");
 
-  const multiSectionRange = Range.create(s1, 'plain textbold te'.length,
-                                      s2, 'link'.length);
+  const multiSectionRange = Range.create(
+    s1,
+    "plain textbold te".length,
+    s2,
+    "link".length
+  );
   found = post.markupsInRange(multiSectionRange);
-  assert.equal(found.length, 3, 'finds all markups in multi-section range');
-  assert.inArray(b, found, 'finds b');
-  assert.inArray(i, found, 'finds i');
-  assert.inArray(a1, found, 'finds a1');
+  assert.equal(found.length, 3, "finds all markups in multi-section range");
+  assert.inArray(b, found, "finds b");
+  assert.inArray(i, found, "finds i");
+  assert.inArray(a1, found, "finds a1");
 
-  const rangeSpanningCard = Range.create(s1, 0, s3, 'link'.length);
+  const rangeSpanningCard = Range.create(s1, 0, s3, "link".length);
   found = post.markupsInRange(rangeSpanningCard);
-  assert.equal(found.length, 4, 'finds all markups in spanning section range');
-  assert.inArray(b, found, 'finds b');
-  assert.inArray(i, found, 'finds i');
-  assert.inArray(a1, found, 'finds a1');
-  assert.inArray(a2, found, 'finds a2');
+  assert.equal(found.length, 4, "finds all markups in spanning section range");
+  assert.inArray(b, found, "finds b");
+  assert.inArray(i, found, "finds i");
+  assert.inArray(a1, found, "finds a1");
+  assert.inArray(a2, found, "finds a2");
 });
 
-test('#markupsInRange obeys left- and right-inclusive rules for "A" markups', (assert) => {
+test('#markupsInRange obeys left- and right-inclusive rules for "A" markups', assert => {
   let a;
-  let post = Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
-    a = markup('a', {href: 'example.com'});
-    return post([markupSection('p', [
-      marker('123', [a]),
-      marker(' abc '),
-      marker('def', [a]),
-      marker(' ghi '),
-      marker('jkl', [a])
-    ])]);
-  });
+  let post = Helpers.postAbstract.build(
+    ({ post, markupSection, marker, markup }) => {
+      a = markup("a", { href: "example.com" });
+      return post([
+        markupSection("p", [
+          marker("123", [a]),
+          marker(" abc "),
+          marker("def", [a]),
+          marker(" ghi "),
+          marker("jkl", [a])
+        ])
+      ]);
+    }
+  );
 
   let section = post.sections.head;
   let start = Range.create(section, 0);
-  let left = Range.create(section, '123 abc '.length);
-  let inside = Range.create(section, '123 abc d'.length);
-  let right = Range.create(section, '123 abc def'.length);
-  let end = Range.create(section, '123 abc def ghi jkl'.length);
+  let left = Range.create(section, "123 abc ".length);
+  let inside = Range.create(section, "123 abc d".length);
+  let right = Range.create(section, "123 abc def".length);
+  let end = Range.create(section, "123 abc def ghi jkl".length);
 
-  assert.deepEqual(post.markupsInRange(start), [], 'no markups at start');
-  assert.deepEqual(post.markupsInRange(left), [], 'no markups at left');
-  assert.deepEqual(post.markupsInRange(right), [], 'no markups at right');
+  assert.deepEqual(post.markupsInRange(start), [], "no markups at start");
+  assert.deepEqual(post.markupsInRange(left), [], "no markups at left");
+  assert.deepEqual(post.markupsInRange(right), [], "no markups at right");
   assert.deepEqual(post.markupsInRange(inside), [a], '"A" markup inside range');
-  assert.deepEqual(post.markupsInRange(end), [], 'no markups at end');
+  assert.deepEqual(post.markupsInRange(end), [], "no markups at end");
 });
 
-test('#markersContainedByRange when range is single marker', (assert) => {
+test("#markersContainedByRange when range is single marker", assert => {
   let found;
-  const post = Helpers.postAbstract.build(({post, marker, markupSection}) => {
-    return post([markupSection('p', [marker('abc')])]);
+  const post = Helpers.postAbstract.build(({ post, marker, markupSection }) => {
+    return post([markupSection("p", [marker("abc")])]);
   });
 
   const innerRange = Range.create(post.sections.head, 1, post.sections.head, 2);
   found = post.markersContainedByRange(innerRange);
-  assert.equal(found.length, 0, '0 markers in innerRange');
+  assert.equal(found.length, 0, "0 markers in innerRange");
 
   const outerRange = Range.create(post.sections.head, 0, post.sections.head, 3);
   found = post.markersContainedByRange(outerRange);
-  assert.equal(found.length, 1, '1 marker in outerRange');
-  assert.ok(found[0] === post.sections.head.markers.head, 'finds right marker');
+  assert.equal(found.length, 1, "1 marker in outerRange");
+  assert.ok(found[0] === post.sections.head.markers.head, "finds right marker");
 });
 
-test('#markersContainedByRange when range is single section', (assert) => {
+test("#markersContainedByRange when range is single section", assert => {
   let found;
-  const post = Helpers.postAbstract.build(({post, marker, markupSection}) => {
-    return post([markupSection('p', [
-      marker('abc'), marker('def'), marker('ghi')
-    ])]);
+  const post = Helpers.postAbstract.build(({ post, marker, markupSection }) => {
+    return post([
+      markupSection("p", [marker("abc"), marker("def"), marker("ghi")])
+    ]);
   });
 
   const section = post.sections.head;
 
   const innerRange = Range.create(section, 2, section, 4);
   found = post.markersContainedByRange(innerRange);
-  assert.equal(found.length, 0, '0 markers in innerRange');
+  assert.equal(found.length, 0, "0 markers in innerRange");
 
   const middleRange = Range.create(section, 2, section, 7);
   found = post.markersContainedByRange(middleRange);
-  assert.equal(found.length, 1, '1 markers in middleRange');
-  assert.ok(found[0] === section.markers.objectAt(1), 'finds right marker');
+  assert.equal(found.length, 1, "1 markers in middleRange");
+  assert.ok(found[0] === section.markers.objectAt(1), "finds right marker");
 
   const middleRangeLeftFencepost = Range.create(section, 3, section, 7);
   found = post.markersContainedByRange(middleRangeLeftFencepost);
-  assert.equal(found.length, 1, '1 markers in middleRangeLeftFencepost');
-  assert.ok(found[0] === section.markers.objectAt(1), 'finds right marker');
+  assert.equal(found.length, 1, "1 markers in middleRangeLeftFencepost");
+  assert.ok(found[0] === section.markers.objectAt(1), "finds right marker");
 
   const middleRangeRightFencepost = Range.create(section, 2, section, 6);
   found = post.markersContainedByRange(middleRangeRightFencepost);
-  assert.equal(found.length, 1, '1 markers in middleRangeRightFencepost');
-  assert.ok(found[0] === section.markers.objectAt(1), 'finds right marker');
+  assert.equal(found.length, 1, "1 markers in middleRangeRightFencepost");
+  assert.ok(found[0] === section.markers.objectAt(1), "finds right marker");
 
   const middleRangeBothFencepost = Range.create(section, 3, section, 6);
   found = post.markersContainedByRange(middleRangeBothFencepost);
-  assert.equal(found.length, 1, '1 markers in middleRangeBothFencepost');
-  assert.ok(found[0] === section.markers.objectAt(1), 'finds right marker');
+  assert.equal(found.length, 1, "1 markers in middleRangeBothFencepost");
+  assert.ok(found[0] === section.markers.objectAt(1), "finds right marker");
 
   const outerRange = Range.create(section, 0, section, section.length);
   found = post.markersContainedByRange(outerRange);
-  assert.equal(found.length, section.markers.length, 'all markers in outerRange');
+  assert.equal(
+    found.length,
+    section.markers.length,
+    "all markers in outerRange"
+  );
 });
 
-test('#markersContainedByRange when range is contiguous sections', (assert) => {
+test("#markersContainedByRange when range is contiguous sections", assert => {
   let found;
-  const post = Helpers.postAbstract.build(({post, marker, markupSection}) => {
+  const post = Helpers.postAbstract.build(({ post, marker, markupSection }) => {
     return post([
-      markupSection('p', [marker('abc'), marker('def'), marker('ghi')]),
-      markupSection('p', [marker('123'), marker('456'), marker('789')])
+      markupSection("p", [marker("abc"), marker("def"), marker("ghi")]),
+      markupSection("p", [marker("123"), marker("456"), marker("789")])
     ]);
   });
 
-  const headSection = post.sections.head, tailSection = post.sections.tail;
+  const headSection = post.sections.head,
+    tailSection = post.sections.tail;
 
   const innerRange = Range.create(headSection, 7, tailSection, 2);
   found = post.markersContainedByRange(innerRange);
-  assert.equal(found.length, 0, '0 markers in innerRange');
+  assert.equal(found.length, 0, "0 markers in innerRange");
 
   const middleRange = Range.create(headSection, 5, tailSection, 4);
   found = post.markersContainedByRange(middleRange);
-  assert.equal(found.length, 2, '2 markers in middleRange');
-  assert.ok(found[0] === headSection.markers.objectAt(2), 'finds right head marker');
-  assert.ok(found[1] === tailSection.markers.objectAt(0), 'finds right tail marker');
+  assert.equal(found.length, 2, "2 markers in middleRange");
+  assert.ok(
+    found[0] === headSection.markers.objectAt(2),
+    "finds right head marker"
+  );
+  assert.ok(
+    found[1] === tailSection.markers.objectAt(0),
+    "finds right tail marker"
+  );
 
   const middleRangeLeftFencepost = Range.create(headSection, 6, tailSection, 2);
   found = post.markersContainedByRange(middleRangeLeftFencepost);
-  assert.equal(found.length, 1, '1 markers in middleRangeLeftFencepost');
-  assert.ok(found[0] === headSection.markers.objectAt(2), 'finds right head marker');
+  assert.equal(found.length, 1, "1 markers in middleRangeLeftFencepost");
+  assert.ok(
+    found[0] === headSection.markers.objectAt(2),
+    "finds right head marker"
+  );
 
-  const middleRangeRightFencepost = Range.create(headSection, 7, tailSection, 3);
+  const middleRangeRightFencepost = Range.create(
+    headSection,
+    7,
+    tailSection,
+    3
+  );
   found = post.markersContainedByRange(middleRangeRightFencepost);
-  assert.equal(found.length, 1, '1 markers in middleRangeRightFencepost');
-  assert.ok(found[0] === tailSection.markers.objectAt(0), 'finds right marker');
+  assert.equal(found.length, 1, "1 markers in middleRangeRightFencepost");
+  assert.ok(found[0] === tailSection.markers.objectAt(0), "finds right marker");
 
   const middleRangeBothFencepost = Range.create(headSection, 6, tailSection, 3);
   found = post.markersContainedByRange(middleRangeBothFencepost);
-  assert.equal(found.length, 2, '2 markers in middleRangeBothFencepost');
-  assert.ok(found[0] === headSection.markers.objectAt(2), 'finds right head marker');
-  assert.ok(found[1] === tailSection.markers.objectAt(0), 'finds right tail marker');
+  assert.equal(found.length, 2, "2 markers in middleRangeBothFencepost");
+  assert.ok(
+    found[0] === headSection.markers.objectAt(2),
+    "finds right head marker"
+  );
+  assert.ok(
+    found[1] === tailSection.markers.objectAt(0),
+    "finds right tail marker"
+  );
 
-  const outerRange = Range.create(headSection, 0, tailSection, tailSection.length);
+  const outerRange = Range.create(
+    headSection,
+    0,
+    tailSection,
+    tailSection.length
+  );
   found = post.markersContainedByRange(outerRange);
-  assert.equal(found.length,
-               headSection.markers.length + tailSection.markers.length,
-               'all markers in outerRange');
+  assert.equal(
+    found.length,
+    headSection.markers.length + tailSection.markers.length,
+    "all markers in outerRange"
+  );
 });
 
-test('#isBlank is true when there are no sections', (assert) => {
+test("#isBlank is true when there are no sections", assert => {
   let _post, _section;
-  Helpers.postAbstract.build(({post, markupSection}) => {
+  Helpers.postAbstract.build(({ post, markupSection }) => {
     _post = post();
     _section = markupSection();
   });
@@ -296,189 +362,286 @@ test('#isBlank is true when there are no sections', (assert) => {
   assert.ok(!_post.isBlank);
 });
 
-test('#trimTo creates a post from the given range', (assert) => {
-  let post = Helpers.postAbstract.build(
-    ({post, markupSection, marker}) => {
-    return post([markupSection('p', [marker('abc')])]);
+test("#trimTo creates a post from the given range", assert => {
+  let post = Helpers.postAbstract.build(({ post, markupSection, marker }) => {
+    return post([markupSection("p", [marker("abc")])]);
   });
   const section = post.sections.head;
-  const range = Range.create(section,1,section,2); // "b"
+  const range = Range.create(section, 1, section, 2); // "b"
 
   post = post.trimTo(range);
-  let expected = Helpers.postAbstract.build(({post, marker, markupSection}) => {
-    return post([markupSection('p',[marker('b')])]);
-  });
+  let expected = Helpers.postAbstract.build(
+    ({ post, marker, markupSection }) => {
+      return post([markupSection("p", [marker("b")])]);
+    }
+  );
 
   assert.postIsSimilar(post, expected);
 });
 
-test('#trimTo copies card sections', (assert) => {
-  let cardPayload = {foo: 'bar'};
+test("#trimTo copies card sections", assert => {
+  let cardPayload = { foo: "bar" };
 
   let buildPost = Helpers.postAbstract.build;
 
-  let post = buildPost(
-    ({post, markupSection, marker, cardSection}) => {
+  let post = buildPost(({ post, markupSection, marker, cardSection }) => {
     return post([
-      markupSection('p', [marker('abc')]),
-      cardSection('test-card', cardPayload),
-      markupSection('p', [marker('123')])
+      markupSection("p", [marker("abc")]),
+      cardSection("test-card", cardPayload),
+      markupSection("p", [marker("123")])
     ]);
   });
 
-  const range = Range.create(post.sections.head, 1,  // 'b'
-                             post.sections.tail, 1); // '2'
+  const range = Range.create(
+    post.sections.head,
+    1, // 'b'
+    post.sections.tail,
+    1
+  ); // '2'
 
   post = post.trimTo(range);
-  let expected = buildPost(
-    ({post, marker, markupSection, cardSection}) => {
+  let expected = buildPost(({ post, marker, markupSection, cardSection }) => {
     return post([
-      markupSection('p',[marker('bc')]),
-      cardSection('test-card', {foo: 'bar'}),
-      markupSection('p',[marker('1')])
+      markupSection("p", [marker("bc")]),
+      cardSection("test-card", cardPayload),
+      markupSection("p", [marker("1")])
     ]);
   });
 
   assert.postIsSimilar(post, expected);
 });
 
-test('#trimTo when range starts and ends in a list item', (assert) => {
+test("#trimTo appends new p section when tail section is not selected and is a non-markerable section", assert => {
+  let cardPayload = { foo: "bar" };
+
   let buildPost = Helpers.postAbstract.build;
 
-  let post = buildPost(
-    ({post, listSection, listItem, marker}) => {
-    return post([listSection('ul', [listItem([marker('abc')])])]);
-  });
-
-  let range = Range.create(post.sections.head.items.head, 0,
-                           post.sections.head.items.head, 'ab'.length);
-
-  post = post.trimTo(range);
-  let expected = buildPost(
-    ({post, listSection, listItem, marker}) => {
-    return post([listSection('ul', [listItem([marker('ab')])])]);
-  });
-
-  assert.postIsSimilar(post, expected);
-});
-
-test('#trimTo when range contains multiple list items', (assert) => {
-  let buildPost = Helpers.postAbstract.build;
-
-  let post = buildPost(
-    ({post, listSection, listItem, marker}) => {
-    return post([listSection('ul', [
-      listItem([marker('abc')]),
-      listItem([marker('def')]),
-      listItem([marker('ghi')])
-    ])]);
-  });
-
-  let range = Range.create(post.sections.head.items.head, 'ab'.length,
-                           post.sections.head.items.tail, 'gh'.length);
-
-  post = post.trimTo(range);
-  let expected = buildPost(
-    ({post, listSection, listItem, marker}) => {
-    return post([listSection('ul', [
-      listItem([marker('c')]),
-      listItem([marker('def')]),
-      listItem([marker('gh')])
-    ])]);
-  });
-
-  assert.postIsSimilar(post, expected);
-});
-
-test('#trimTo when range contains multiple list items and more sections', (assert) => {
-  let buildPost = Helpers.postAbstract.build;
-
-  let post = buildPost(
-    ({post, listSection, listItem, markupSection, marker}) => {
-    return post([listSection('ul', [
-      listItem([marker('abc')]),
-      listItem([marker('def')]),
-      listItem([marker('ghi')])
-    ]), markupSection('p', [
-      marker('123')
-    ])]);
-  });
-
-  let range = Range.create(post.sections.head.items.head, 'ab'.length,
-                           post.sections.tail, '12'.length);
-
-  post = post.trimTo(range);
-  let expected = buildPost(
-    ({post, listSection, listItem, markupSection, marker}) => {
-    return post([listSection('ul', [
-      listItem([marker('c')]),
-      listItem([marker('def')]),
-      listItem([marker('ghi')])
-    ]), markupSection('p', [
-      marker('12')
-    ])]);
-  });
-
-  assert.postIsSimilar(post, expected);
-});
-
-test('#headPosition and #tailPosition returns head and tail', (assert) => {
-  let post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+  let post = buildPost(({ post, markupSection, marker, cardSection }) => {
     return post([
-      markupSection('p', [marker('abc')]),
-      markupSection('p', [marker('123')])
+      markupSection("p", [marker("abc")]),
+      cardSection("test-card", cardPayload)
+    ]);
+  });
+
+  const range = Range.create(
+    post.sections.head,
+    1, // b
+    post.sections.tail,
+    0
+  ); // start of card
+
+  post = post.trimTo(range);
+  let expected = buildPost(({ post, marker, markupSection, cardSection }) => {
+    return post([
+      markupSection("p", [marker("bc")]),
+      markupSection("p", [marker("")]),
+      cardSection("test-card", cardPayload)
+    ]);
+  });
+
+  const newSection = expected.sections.head.next;
+  assert.equal(expected.sections.length, 3);
+  assert.equal(newSection.tagName, "p");
+  assert.equal(newSection.isBlank, true);
+});
+
+test("#trimTo appends new p section when tail section is not selected and is a markerable section", assert => {
+  let cardPayload = { foo: "bar" };
+
+  let buildPost = Helpers.postAbstract.build;
+
+  let post = buildPost(({ post, markupSection, marker }) => {
+    return post([
+      markupSection("p", [marker("abc")]),
+      markupSection("p", [marker("123")])
+    ]);
+  });
+
+  const range = Range.create(
+    post.sections.head,
+    1, // b
+    post.sections.tail,
+    0
+  ); // start of 123
+
+  post = post.trimTo(range);
+  let expected = buildPost(({ post, marker, markupSection }) => {
+    return post([
+      markupSection("p", [marker("bc")]),
+      markupSection("p", [marker("")]),
+      markupSection("p", [marker("123")])
+    ]);
+  });
+
+  const newSection = expected.sections.head.next;
+  assert.equal(expected.sections.length, 3);
+  assert.equal(newSection.tagName, "p");
+  assert.equal(newSection.isBlank, true);
+});
+
+test("#trimTo when range starts and ends in a list item", assert => {
+  let buildPost = Helpers.postAbstract.build;
+
+  let post = buildPost(({ post, listSection, listItem, marker }) => {
+    return post([listSection("ul", [listItem([marker("abc")])])]);
+  });
+
+  let range = Range.create(
+    post.sections.head.items.head,
+    0,
+    post.sections.head.items.head,
+    "ab".length
+  );
+
+  post = post.trimTo(range);
+  let expected = buildPost(({ post, listSection, listItem, marker }) => {
+    return post([listSection("ul", [listItem([marker("ab")])])]);
+  });
+
+  assert.postIsSimilar(post, expected);
+});
+
+test("#trimTo when range contains multiple list items", assert => {
+  let buildPost = Helpers.postAbstract.build;
+
+  let post = buildPost(({ post, listSection, listItem, marker }) => {
+    return post([
+      listSection("ul", [
+        listItem([marker("abc")]),
+        listItem([marker("def")]),
+        listItem([marker("ghi")])
+      ])
+    ]);
+  });
+
+  let range = Range.create(
+    post.sections.head.items.head,
+    "ab".length,
+    post.sections.head.items.tail,
+    "gh".length
+  );
+
+  post = post.trimTo(range);
+  let expected = buildPost(({ post, listSection, listItem, marker }) => {
+    return post([
+      listSection("ul", [
+        listItem([marker("c")]),
+        listItem([marker("def")]),
+        listItem([marker("gh")])
+      ])
+    ]);
+  });
+
+  assert.postIsSimilar(post, expected);
+});
+
+test("#trimTo when range contains multiple list items and more sections", assert => {
+  let buildPost = Helpers.postAbstract.build;
+
+  let post = buildPost(
+    ({ post, listSection, listItem, markupSection, marker }) => {
+      return post([
+        listSection("ul", [
+          listItem([marker("abc")]),
+          listItem([marker("def")]),
+          listItem([marker("ghi")])
+        ]),
+        markupSection("p", [marker("123")])
+      ]);
+    }
+  );
+
+  let range = Range.create(
+    post.sections.head.items.head,
+    "ab".length,
+    post.sections.tail,
+    "12".length
+  );
+
+  post = post.trimTo(range);
+  let expected = buildPost(
+    ({ post, listSection, listItem, markupSection, marker }) => {
+      return post([
+        listSection("ul", [
+          listItem([marker("c")]),
+          listItem([marker("def")]),
+          listItem([marker("ghi")])
+        ]),
+        markupSection("p", [marker("12")])
+      ]);
+    }
+  );
+
+  assert.postIsSimilar(post, expected);
+});
+
+test("#headPosition and #tailPosition returns head and tail", assert => {
+  let post = Helpers.postAbstract.build(({ post, markupSection, marker }) => {
+    return post([
+      markupSection("p", [marker("abc")]),
+      markupSection("p", [marker("123")])
     ]);
   });
 
   let head = post.headPosition();
   let tail = post.tailPosition();
 
-  assert.positionIsEqual(head, post.sections.head.headPosition(), 'head pos');
-  assert.positionIsEqual(tail, post.sections.tail.tailPosition(), 'tail pos');
+  assert.positionIsEqual(head, post.sections.head.headPosition(), "head pos");
+  assert.positionIsEqual(tail, post.sections.tail.tailPosition(), "tail pos");
 });
 
-test('#headPosition and #tailPosition when post is blank return blank', (assert) => {
-  let post = Helpers.postAbstract.build(({post}) => {
+test("#headPosition and #tailPosition when post is blank return blank", assert => {
+  let post = Helpers.postAbstract.build(({ post }) => {
     return post();
   });
 
   let head = post.headPosition();
   let tail = post.tailPosition();
 
-  assert.positionIsEqual(head, Position.blankPosition(), 'head pos');
-  assert.positionIsEqual(tail, Position.blankPosition(), 'tail pos');
+  assert.positionIsEqual(head, Position.blankPosition(), "head pos");
+  assert.positionIsEqual(tail, Position.blankPosition(), "tail pos");
 });
 
-test('#hasContent gives correct value', (assert) => {
-  let expectations = Helpers.postAbstract.build(({post, markupSection, imageSection, marker}) => {
-    return {
-      hasNoContent: [{
-        message: 'no sections',
-        post: post()
-      }, {
-        message: '1 blank section',
-        post: post([markupSection('p')])
-      }, {
-        message: '1 section with blank marker',
-        post: post([markupSection('p', [marker('')])])
-      }],
-      hasContent: [{
-        message: '1 section with non-blank marker',
-        post: post([markupSection('p', [marker('text')])])
-      }, {
-        message: '2 sections',
-        post: post([markupSection('p'), markupSection('p')])
-      }, {
-        message: 'image section',
-        post: post([imageSection()])
-      }]
-    };
-  });
+test("#hasContent gives correct value", assert => {
+  let expectations = Helpers.postAbstract.build(
+    ({ post, markupSection, imageSection, marker }) => {
+      return {
+        hasNoContent: [
+          {
+            message: "no sections",
+            post: post()
+          },
+          {
+            message: "1 blank section",
+            post: post([markupSection("p")])
+          },
+          {
+            message: "1 section with blank marker",
+            post: post([markupSection("p", [marker("")])])
+          }
+        ],
+        hasContent: [
+          {
+            message: "1 section with non-blank marker",
+            post: post([markupSection("p", [marker("text")])])
+          },
+          {
+            message: "2 sections",
+            post: post([markupSection("p"), markupSection("p")])
+          },
+          {
+            message: "image section",
+            post: post([imageSection()])
+          }
+        ]
+      };
+    }
+  );
 
-  expectations.hasNoContent.forEach(({message, post}) => {
-    assert.ok(!post.hasContent, message + ' !hasContent');
+  expectations.hasNoContent.forEach(({ message, post }) => {
+    assert.ok(!post.hasContent, message + " !hasContent");
   });
-  expectations.hasContent.forEach(({message, post}) => {
-    assert.ok(post.hasContent, message + ' hasContent');
+  expectations.hasContent.forEach(({ message, post }) => {
+    assert.ok(post.hasContent, message + " hasContent");
   });
 });


### PR DESCRIPTION
Fixes 2 bugs around double clicking a paragraph to modify/copy-paste it:

1) Issue: if a user double clicks to select and copy a paragraph that has a card following it, the card gets caught up in the copy and will also be pasted wherever you try to paste the paragraph
Fix: rather than copying the card we now insert a new blank paragraph

2) Issue: if a user double clicks to select a paragraph to add section level markup and there is another paragraph following the selected one the second paragraph will also have the section level markup applied to it
Fix: only apply markdown to selected sections
 