### PR TITLE
[Bug Fix] don't modify tail.section if offset is 0 (aka tail.section is not selected)

### DIFF
--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -788,11 +788,20 @@ class PostEditor {
   toggleSection(sectionTagName, range=this._range) {
     range = toRange(range);
 
+    const { head, tail } = range;
+    const togglingList = sectionTagName === 'ul';
+    const tailNotSelected = tail.offset === 0 && head.section !== tail.section;
+
     sectionTagName = normalizeTagName(sectionTagName);
     let { post } = this.editor;
 
     let everySectionHasTagName = true;
     post.walkMarkerableSections(range, section => {
+      // only care about tail section tag if tail section is selected
+      if (!togglingList && tailNotSelected && tail.section === section) {
+        return;
+      }
+
       if (!this._isSameSectionType(section, sectionTagName)) {
         everySectionHasTagName = false;
       }
@@ -801,7 +810,15 @@ class PostEditor {
     let tagName = everySectionHasTagName ? 'p' : sectionTagName;
     let sectionTransformations = [];
     post.walkMarkerableSections(range, section => {
-      let changedSection = this.changeSectionTagName(section, tagName);
+      let changedSection;
+
+      // tail section not selected, no transform needed
+      if (!togglingList && tailNotSelected && tail.section === section) {
+        changedSection = section;
+      } else {
+        changedSection = this.changeSectionTagName(section, tagName);
+      }
+
       sectionTransformations.push({
         from: section,
         to: changedSection

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -214,8 +214,7 @@ class Post {
         } else {
           listParent = null;
           sectionParent = post;
-          const tagName =
-            tailNotSelected && tail.section === section ? 'p' : section.tagName;
+          const tagName = tailNotSelected && tail.section === section ? 'p' : section.tagName;
           newSection = builder.createMarkupSection(tagName);
         }
 
@@ -228,7 +227,7 @@ class Post {
         newSection = tailNotSelected && tail.section === section ?
             builder.createMarkupSection('p') :
             section.clone();
-        
+
         sectionParent = post;
       }
       if (sectionParent) {

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -214,7 +214,9 @@ class Post {
         } else {
           listParent = null;
           sectionParent = post;
-          const tagName = tailNotSelected && tail.section === section ? 'p' : section.tagName;
+          const tagName = tailNotSelected && tail.section === section ?
+              'p' :
+              section.tagName;
           newSection = builder.createMarkupSection(tagName);
         }
 

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -193,6 +193,8 @@ class Post {
   trimTo(range) {
     const post = this.builder.createPost();
     const { builder } = this;
+    const { head, tail } = range;
+    const tailNotSelected = tail.offset === 0 && head.section !== tail.section;
 
     let sectionParent = post,
         listParent = null;
@@ -212,7 +214,9 @@ class Post {
         } else {
           listParent = null;
           sectionParent = post;
-          newSection = builder.createMarkupSection(section.tagName);
+          const tagName =
+            tailNotSelected && tail.section === section ? 'p' : section.tagName;
+          newSection = builder.createMarkupSection(tagName);
         }
 
         let currentRange = range.trimTo(section);
@@ -221,7 +225,10 @@ class Post {
           m => newSection.markers.append(m)
         );
       } else {
-        newSection = section.clone();
+        newSection =
+          tailNotSelected && tail.section === section
+            ? builder.createMarkupSection('p')
+            : section.clone();
         sectionParent = post;
       }
       if (sectionParent) {

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -225,10 +225,10 @@ class Post {
           m => newSection.markers.append(m)
         );
       } else {
-        newSection =
-          tailNotSelected && tail.section === section
-            ? builder.createMarkupSection('p')
-            : section.clone();
+        newSection = tailNotSelected && tail.section === section ?
+            builder.createMarkupSection('p') :
+            section.clone();
+        
         sectionParent = post;
       }
       if (sectionParent) {

--- a/tests/unit/editor/post-test.js
+++ b/tests/unit/editor/post-test.js
@@ -881,6 +881,43 @@ test('#toggleSection changes multiple sections to and from tag name', (assert) =
   );
 });
 
+test('#toggleSection does not update tail markup if tail offset is 0', assert => {
+  let post = Helpers.postAbstract.build(({ post, markupSection, marker }) => {
+    return post([
+      markupSection('p', [marker('abc')]),
+      markupSection('p', [marker('123')])
+    ]);
+  });
+
+  mockEditor = renderBuiltAbstract(post, mockEditor);
+  const range = Range.create(post.sections.head, 2, post.sections.tail, 0);
+
+  postEditor = new PostEditor(mockEditor);
+  postEditor.toggleSection('blockquote', range);
+  postEditor.complete();
+
+  assert.equal(post.sections.head.tagName, 'blockquote');
+  assert.equal(post.sections.tail.tagName, 'p');
+
+  postEditor = new PostEditor(mockEditor);
+  postEditor.toggleSection('blockquote', range);
+  postEditor.complete();
+
+  assert.equal(post.sections.head.tagName, 'p');
+  assert.equal(post.sections.tail.tagName, 'p');
+
+  assert.positionIsEqual(
+      mockEditor._renderedRange.head,
+      post.sections.head.toPosition(2),
+      'Maintains the selection'
+  );
+  assert.positionIsEqual(
+      mockEditor._renderedRange.tail,
+      post.sections.tail.toPosition(0),
+      'Maintains the selection'
+  );
+});
+
 test('#toggleSection skips over non-markerable sections', (assert) => {
   let post = Helpers.postAbstract.build(
     ({post, markupSection, marker, cardSection}) => {

--- a/tests/unit/editor/post-test.js
+++ b/tests/unit/editor/post-test.js
@@ -913,7 +913,7 @@ test('#toggleSection does not update tail markup if tail offset is 0', assert =>
   );
   assert.positionIsEqual(
       mockEditor._renderedRange.tail,
-      post.sections.tail.toPosition(0),
+      post.sections.head.toPosition(3),
       'Maintains the selection'
   );
 });
@@ -1073,7 +1073,7 @@ test('#toggleSection toggle multiple ps -> list and list -> multiple ps', (asser
   assert.equal(listSection.items.head.text, 'abc');
   assert.equal(listSection.items.tail.text, '123');
 
-  range = Range.create(listSection.items.head, 0, listSection.items.tail, 0);
+  range = Range.create(listSection.items.head, 0, listSection.items.tail, 1);
   postEditor = new PostEditor(editor);
   postEditor.toggleSection('ul', range);
   postEditor.complete();
@@ -1196,7 +1196,7 @@ test('#toggleSection untoggle multiple items at end of list changes them to mark
   });
   mockEditor = renderBuiltAbstract(post, mockEditor);
   let range = Range.create(post.sections.head.items.objectAt(1), 0,
-                           post.sections.head.items.tail, 0);
+                           post.sections.head.items.tail, 1);
 
   postEditor = new PostEditor(mockEditor);
   postEditor.toggleSection('ul', range);
@@ -1226,7 +1226,7 @@ test('#toggleSection untoggle multiple items at start of list changes them to ma
   });
   mockEditor = renderBuiltAbstract(post, mockEditor);
   let range = Range.create(post.sections.head.items.head, 0,
-                           post.sections.head.items.objectAt(1), 0);
+                           post.sections.head.items.objectAt(1), 1);
 
   postEditor = new PostEditor(mockEditor);
   postEditor.toggleSection('ul', range);
@@ -1262,7 +1262,7 @@ test('#toggleSection untoggle items and overflowing markup sections changes the 
   editor.render(editorElement);
   let { post } = editor;
   let range = Range.create(post.sections.head.items.objectAt(1), 0,
-                           post.sections.tail, 0);
+                           post.sections.tail, 1);
 
   postEditor = new PostEditor(editor);
   postEditor.toggleSection('ul', range);

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -342,6 +342,68 @@ test('#trimTo copies card sections', (assert) => {
   assert.postIsSimilar(post, expected);
 });
 
+
+test('#trimTo appends new p section when tail section is not selected and is a non-markerable section', assert => {
+  let cardPayload = { foo: 'bar' };
+
+  let buildPost = Helpers.postAbstract.build;
+
+  let post = buildPost(({ post, markupSection, marker, cardSection }) => {
+    return post([
+      markupSection('p', [marker('abc')]),
+      cardSection('test-card', cardPayload)
+    ]);
+  });
+
+  const range = Range.create(post.sections.head, 1, // b
+                             post.sections.tail, 0); // start of card
+
+  post = post.trimTo(range);
+  let expected = buildPost(({ post, marker, markupSection, cardSection }) => {
+    return post([
+      markupSection('p', [marker('bc')]),
+      markupSection('p', [marker('')]),
+      cardSection('test-card', cardPayload)
+    ]);
+  });
+
+  const newSection = expected.sections.head.next;
+  assert.equal(expected.sections.length, 3);
+  assert.equal(newSection.tagName, 'p');
+  assert.equal(newSection.isBlank, true);
+});
+
+test('#trimTo appends new p section when tail section is not selected and is a markerable section', assert => {
+  let cardPayload = { foo: 'bar' };
+
+  let buildPost = Helpers.postAbstract.build;
+
+  let post = buildPost(({ post, markupSection, marker }) => {
+    return post([
+      markupSection('p', [marker('abc')]),
+      markupSection('p', [marker('123')])
+    ]);
+  });
+
+  const range = Range.create(post.sections.head, 1, // b
+                             post.sections.tail, 0); // start of 123
+
+  post = post.trimTo(range);
+  let expected = buildPost(({ post, marker, markupSection }) => {
+    return post([
+      markupSection('p', [marker('bc')]),
+      markupSection('p', [marker('')]),
+      markupSection('p', [marker('123')])
+    ]);
+  });
+
+  const newSection = expected.sections.head.next;
+  assert.equal(expected.sections.length, 3);
+  assert.equal(newSection.tagName, 'p');
+  assert.equal(newSection.isBlank, true);
+});
+
+
 test('#trimTo when range starts and ends in a list item', (assert) => {
   let buildPost = Helpers.postAbstract.build;
 


### PR DESCRIPTION
Fixes 2 bugs around double clicking a paragraph to modify/copy-paste it:

1. Issue: if a user double clicks to select and copy a paragraph that has a card following it, the card gets caught up in the copy and will also be pasted wherever you try to paste the paragraph
Fix: rather than copying the card we now insert a new blank paragraph

2. Issue: if a user double clicks to select a paragraph to add section level markup and there is another paragraph following the selected one the second paragraph will also have the section level markup applied to it
Fix: only apply markdown to selected sections