### PR TITLE
Fixed section parser handling of markup sections inside lists

### DIFF
--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -152,6 +152,13 @@ class SectionParser {
       let isNestedListSection = isListSection && this.state.section.isListItem;
       let lastSection = this.sections[this.sections.length - 1];
 
+      // lists can continue after breaking out for a markup section,
+      // in that situation, start a new list using the same list type
+      if (isListItem && this.state.section.isMarkupSection) {
+        this._closeCurrentSection();
+        this._updateStateFromElement(node.parentElement);
+      }
+
       // we can hit a list item after parsing a nested list, when that happens
       // and the lists are of different types we need to make sure we switch
       // the list type back

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -274,6 +274,58 @@ test("#parse handles multiple headers in list item", assert => {
   assert.equal(h2.tagName, 'h2');
 });
 
+// https://github.com/bustle/mobiledoc-kit/issues/714
+test('#parse handles list items following a markup-section breakout', (assert) => {
+  let container = buildDOM(`
+    <ul><li>One</li><li><h2>Two</h2></li><li>Three</li><li>Four</li></ul>
+  `);
+
+  let element = container.firstChild;
+  parser = new SectionParser(builder);
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 3, '3 sections');
+
+  assert.equal(sections[0].type, 'list-section');
+  assert.equal(sections[0].items.length, 1);
+  assert.equal(sections[0].items.objectAt(0).text, 'One');
+
+  assert.equal(sections[1].type, 'markup-section');
+  assert.equal(sections[1].tagName, 'h2');
+  assert.equal(sections[1].text, 'Two');
+
+  assert.equal(sections[2].type, 'list-section');
+  assert.equal(sections[2].items.length, 2);
+  assert.equal(sections[2].items.objectAt(0).text, 'Three');
+  assert.equal(sections[2].items.objectAt(1).text, 'Four');
+});
+
+// https://github.com/bustle/mobiledoc-kit/issues/714
+test('#parse handles "invalid" non-li elems inside lists', (assert) => {
+  let container = buildDOM(`
+    <ul><li>One</li><h2>Two</h2><li>Three</li><li>Four</li></ul>
+  `);
+
+  let element = container.firstChild;
+  parser = new SectionParser(builder);
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 3, '3 sections');
+
+  assert.equal(sections[0].type, 'list-section');
+  assert.equal(sections[0].items.length, 1);
+  assert.equal(sections[0].items.objectAt(0).text, 'One');
+
+  assert.equal(sections[1].type, 'markup-section');
+  assert.equal(sections[1].tagName, 'h2');
+  assert.equal(sections[1].text, 'Two');
+
+  assert.equal(sections[2].type, 'list-section');
+  assert.equal(sections[2].items.length, 2);
+  assert.equal(sections[2].items.objectAt(0).text, 'Three');
+  assert.equal(sections[2].items.objectAt(1).text, 'Four');
+});
+
 // see https://github.com/bustle/mobiledoc-kit/issues/656
 test('#parse handles list following node handled by parserPlugin', (assert) => {
   let container = buildDOM(`
@@ -536,3 +588,4 @@ test('#parse handles card-creating element after plain text', (assert) => {
   assert.equal(sections[1].type, 'card-section');
   assert.equal(sections[2].text.trim(), 'After');
 });
+


### PR DESCRIPTION
closes https://github.com/bustle/mobiledoc-kit/issues/714

- if the section parser hits a list item and it's current state is not a previous list item or a list section then open a new list section using using the LI's parent list type
- prevents `ListItem` sections being created outside of a `ListSection`