### PR TITLE
Improved section parser handling of blockquote>p

### DIFF
--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -373,12 +373,23 @@ class SectionParser {
     let sectionType,
         tagName,
         inferredTagName = false;
+
     if (isTextNode(element)) {
       tagName = DEFAULT_TAG_NAME;
       sectionType = MARKUP_SECTION_TYPE;
       inferredTagName = true;
     } else {
       tagName = normalizeTagName(element.tagName);
+
+      // blockquote>p is valid html and should be treated as a blockquote section
+      // rather than a plain markup section
+      if (
+        tagName === 'p' &&
+        element.parentElement &&
+        normalizeTagName(element.parentElement.tagName) === 'blockquote'
+      ) {
+        tagName = 'blockquote';
+      }
 
       if (contains(VALID_LIST_SECTION_TAGNAMES, tagName)) {
         sectionType = LIST_SECTION_TYPE;

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -589,3 +589,22 @@ test('#parse handles card-creating element after plain text', (assert) => {
   assert.equal(sections[2].text.trim(), 'After');
 });
 
+test('#parse handles <p> inside <blockquote>', (assert) => {
+  let container = buildDOM(`
+    <blockquote>
+      <p>One</p>
+      <p>Two</p>
+    </blockquote>
+  `);
+
+  parser = new SectionParser(builder);
+  let sections = parser.parse(container.firstChild);
+
+  assert.equal(sections.length, 2, '2 sections');
+  assert.equal(sections[0].type, 'markup-section');
+  assert.equal(sections[0].tagName, 'blockquote');
+  assert.equal(sections[0].text.trim(), 'One');
+  assert.equal(sections[1].type, 'markup-section');
+  assert.equal(sections[1].tagName, 'blockquote');
+  assert.equal(sections[1].text.trim(), 'Two');
+});


### PR DESCRIPTION
closes https://github.com/bustle/mobiledoc-kit/issues/715

- when the section parser encountered `blockquote>p` structure it was ignoring the blockquote and creating plain markup sections
- adds special handling for `blockquote>p` so that the intention of blockquote semantics is not lost when a blockquote contains one or more paragraphs of quoted content