### PR TITLE
Fixed spaces added by section parser from newlines in html

### DIFF
--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -46,7 +46,7 @@ const SKIPPABLE_ELEMENT_TAG_NAMES = [
   'style', 'head', 'title', 'meta'
 ].map(normalizeTagName);
 
-const NEWLINES = /\n/g;
+const NEWLINES = /\s*\n\s*/g;
 function sanitize(text) {
   return text.replace(NEWLINES, ' ');
 }

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -399,6 +399,13 @@ test('#parse handles insignificant whitespace (wrapped)', (assert) => {
   assert.equal(list.items.objectAt(0).text, 'One');
 });
 
+test('#parse handles insignificant whitespace around newlines', (assert) => {
+  let container = buildDOM(`<p>One \n Two</p>`);
+  parser = new SectionParser(builder);
+  let sections = parser.parse(container.firstChild);
+
+  assert.equal(sections[0].text, 'One Two');
+});
 
 test('#parse avoids empty paragraph around wrapped list', (assert) => {
   let container = buildDOM(`


### PR DESCRIPTION
closes https://github.com/bustle/mobiledoc-kit/issues/707

- it's frequent to see html with spaces separated by newlines, especially when the html is indented
- whitespace and newlines in html is largely insignificant so we detect this and replace it with a single space to avoid extra whitespace appearing in mobiledoc content