### PR TITLE
Add `del` tag as valid markup

### DIFF
--- a/src/js/models/markup.js
+++ b/src/js/models/markup.js
@@ -10,6 +10,7 @@ export const VALID_MARKUP_TAGNAMES = [
   'em',
   'i',
   's',   // strikethrough
+  'del', // deleted text (also strikethrough)
   'strong',
   'sub', // subscript
   'sup', // superscript


### PR DESCRIPTION
To represent content that is now deleted.

Differences  of strike/s/del

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s

```
The <strike> element, alter ego of the <s> element is obsolete and should not be used on Web sites any more.

The <del> element is to be used instead if the data has been deleted.
```