### PR TITLE
[TooltipPlugin] Shorten hide timer 🍭

### DIFF
--- a/src/js/views/tooltip.js
+++ b/src/js/views/tooltip.js
@@ -4,11 +4,10 @@ import {
   getEventTargetMatchingTag,
   whenElementIsNotInDOM
 } from '../utils/element-utils';
-import Position from '../utils/cursor/position';
 import { editLink } from '../editor/ui';
 
 const SHOW_DELAY = 200;
-const HIDE_DELAY = 1000;
+const HIDE_DELAY = 600;
 
 export default class Tooltip extends View {
   constructor(options) {


### PR DESCRIPTION
`1000` was too high for users, so this PR shortens the timer to `600` for good measure.