### PR TITLE
Fix IME bugs

### DIFF
--- a/src/js/editor/event-manager.js
+++ b/src/js/editor/event-manager.js
@@ -6,13 +6,24 @@ import TextInputHandler from 'mobiledoc-kit/editor/text-input-handler'
 import SelectionManager from 'mobiledoc-kit/editor/selection-manager'
 import Browser from 'mobiledoc-kit/utils/browser'
 
-const ELEMENT_EVENT_TYPES = ['keydown', 'keyup', 'cut', 'copy', 'paste', 'keypress', 'drop']
+const ELEMENT_EVENT_TYPES = [
+  'keydown',
+  'keyup',
+  'cut',
+  'copy',
+  'paste',
+  'keypress',
+  'drop',
+  'compositionstart',
+  'compositionend',
+]
 
 export default class EventManager {
   constructor(editor) {
     this.editor = editor
     this.logger = editor.loggerFor('event-manager')
     this._textInputHandler = new TextInputHandler(editor)
+    this._isComposingOnBlankLine = false
     this._listeners = []
     this.modifierKeys = {
       shift: false,
@@ -143,6 +154,12 @@ export default class EventManager {
       event.preventDefault()
     }
 
+    if (!key.isEnter() && (key.toString() === '\r' || key.toString() === '\n')) {
+      _textInputHandler.handleNewLine()
+      editor.handleNewline(event)
+      return
+    }
+
     _textInputHandler.handle(key.toString())
   }
 
@@ -169,6 +186,10 @@ export default class EventManager {
     let range = editor.range
 
     switch (true) {
+      // Ignore tab/arrow/delete keydown events when using an IME
+      case key.isIME(): {
+        break
+      }
       // FIXME This should be restricted to only card/atom boundaries
       case key.isHorizontalArrowWithoutModifiersOtherThanShift(): {
         let newRange
@@ -213,6 +234,65 @@ export default class EventManager {
     }
     let key = Key.fromEvent(event)
     this._updateModifiersFromKey(key, { isDown: false })
+  }
+
+  // The mutation handler interefers with IMEs when composing
+  // on a blank line. These two event handlers are for suppressing
+  // mutation handling in this scenario.
+  compositionstart(event) {
+    event.preventDefault()
+
+    let { editor } = this
+    // Ignore compositionstart if not on a blank line
+    if (editor.range.headMarker) {
+      return
+    }
+    this._isComposingOnBlankLine = true
+
+    if (editor.post.isBlank) {
+      editor._insertEmptyMarkupSectionAtCursor()
+    }
+
+    // Stop listening for mutations on Chrome browsers and suppress
+    // mutations by inputting a null character for other browsers.
+    // The reason why we treat these separately is because
+    // of the order in which each browser deals with the
+    // compositionend and keydown events.
+    if (Browser.isChrome()) {
+      editor.setPlaceholder('')
+      editor._mutationHandler.stopObserving()
+    } else {
+      this._textInputHandler.handle('\0')
+    }
+
+  }
+
+  compositionend(event) {
+    event.preventDefault()
+
+    let { editor } = this
+
+    // Ignore compositionend if not composing on blank line
+    if (!this._isComposingOnBlankLine) {
+      return
+    }
+    this._isComposingOnBlankLine = false
+
+    // Start listening for mutations on Chrome browsers and
+    // delete the null character introduced by compositionstart
+    // for other browsers.
+    if (Browser.isChrome()) {
+      editor.insertText(event.data)
+      editor.setPlaceholder(editor.placeholder)
+      editor._mutationHandler.startObserving()
+    } else {
+      let startOfCompositionLine = editor.range.headSection.toPosition(0)
+      let endOfCompositionLine = editor.range.headSection.toPosition(event.data.length)
+      editor.run(postEditor => {
+        postEditor.deleteAtPosition(startOfCompositionLine, 1, { unit: 'char' })
+        postEditor.setRange(endOfCompositionLine)
+      })
+    }
   }
 
   cut(event) {

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -5,4 +5,7 @@ export default {
   isWin() {
     return typeof window !== 'undefined' && window.navigator && /Win/.test(window.navigator.platform)
   },
+  isChrome() {
+    return typeof window !== 'undefined' && window.chrome
+  },
 }


### PR DESCRIPTION
I think this pull request should fix #548 and #696. I have tested on macOS Catalina with Brave, Chrome, Firefox, Opera, Safari, and Edge and on iOS with Safari. I would appreciate tests on other devices. I will explain my observations on why these bugs occur and how my solution addresses them.

### Problem

There are two separate bugs. One is that IME inputs are duplicated when when pressing Enter (to terminate IME input) and the other is that the IME's input gets modified when inputting on a blank line. The first bug occurs because the Mobiledoc Editor interprets an Enter when using an IME as the same as inputing Enter. As the IME input is buffered, the Mobiledoc Editor cursor is at the position where the IME input begins and when Enter is inputted handleNewline is called (which duplicates the text on the new line). The second bug occurs because of the absence of a markup node in the editor on a blank line. Because of the absence of a markup node and the IME buffering, this causes the Mutation handler to modify the editor DOM which in turn modifies the initial IME input.

### Solution

The first bug can be fixed by ignoring the uses of Enter/Tab when an IME is being used. The second bug can be fixed by getting rid of the offending mutations. One way to do this is to prepend a "dummy" character (I used the null control character) to blank lines when composestart is fired and deleting this character when composeend is fired. This is treated as a the user typing an input (creating a markup node) which prevents the mutation. Another is to stop listening for mutations when composestart is fired and restart listening when composeend is fired. For most browsers, the first solution works and for Chrome-based browsers the second solutions works. This is mostly due to how each browsers manages the order of the events composingend and keydown. Chrome triggers composingend after a keypress event (like delete, enter) to terminate the IME, but most browsers trigger the keypress after composingend which causes problems. Thus the solution I came up with is to use both depending on the browser being used.

### Asides

When inputting accented characters on Safari via the IME, the Enter keypress event is interpreted as a carriage return "\r" and so I have made it so these keypresses are handled as editor newlines instead.

### Other Possible Fixes

I tested #704, but the fix seems to work only for Chrome-based browsers. The code modifications seem simple but I don't quite understand what it does to fix the issue. It may be good to see if this fix can be integrated into mine to fix Chrome at least. #661 seems to be a fix for the first bug.