### PR TITLE
[DOCS] Move to 0.3.2 in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ optionally a Mobiledoc to load. For example:
 
 ```js
 const simpleMobiledoc = {
-  version: "0.3.1",
+  version: "0.3.2",
   markups: [],
   atoms: [],
   cards: [],
@@ -121,7 +121,7 @@ document's `<head>`:
 
 ### Editor API
 
-* `editor.serialize(version="0.3.1")` - serialize the current post for persistence. Returns
+* `editor.serialize(version="0.3.2")` - serialize the current post for persistence. Returns
   Mobiledoc.
 * `editor.destroy()` - teardown the editor event listeners, free memory etc.
 * `editor.disableEditing()` - stop the user from being able to edit the

--- a/tests/acceptance/cursor-movement-test.js
+++ b/tests/acceptance/cursor-movement-test.js
@@ -228,8 +228,7 @@ test('left arrow when at the head of an atom moves the cursor left off the atom'
         marker('cc')
       ])
     ]);
-  // TODO just make 0.3.1 default
-  }, '0.3.1');
+  });
   editor = new Editor({mobiledoc, atoms});
   editor.render(editorElement);
 
@@ -285,8 +284,7 @@ test('right arrow when at the head of an atom moves the cursor across the atom',
         marker('cc')
       ])
     ]);
-  // TODO just make 0.3.1 default
-  }, '0.3.1');
+  });
   editor = new Editor({mobiledoc, atoms});
   editor.render(editorElement);
 


### PR DESCRIPTION
* I noticed that the README of the repo still mentions 0.3.1 as the Mobiledoc version. In the mean time, it has changed to 0.3.2.
* Also updated a test that still used 0.3.1.