### PR TITLE
Pin older Node version for 0.12 release branch 💄

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,9 @@
     "saucie": "^3.3.2",
     "testem": "^2.17.0"
   },
-  "main": "dist/commonjs/mobiledoc-kit/index.js"
+  "main": "dist/commonjs/mobiledoc-kit/index.js",
+  "volta": {
+    "node": "10.22.1",
+    "yarn": "1.22.5"
+  }
 }


### PR DESCRIPTION
To facilitate patch releases for the 0.12.x series, we created the `release-0-12` branch. However, this branch does not build correctly with newer versions of Node that people likely have installed now. This pins the Node version to 10 using Volta to prevent trolling ourselves again in the future.