### PR TITLE
Add additional re-exports

### DIFF
--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -5,6 +5,8 @@ import Range from './utils/cursor/range'
 import Position from './utils/cursor/position'
 import Error from './utils/mobiledoc-error'
 import VERSION from './version'
-import { MOBILEDOC_VERSION } from './renderers/mobiledoc'
+import mobiledocRenderers, { MOBILEDOC_VERSION } from './renderers/mobiledoc'
+import DOMParser from './parsers/dom'
+import PostNodeBuilder from './models/post-node-builder'
 
-export { Editor, UI, ImageCard, Range, Position, Error, VERSION, MOBILEDOC_VERSION }
+export { Editor, UI, ImageCard, Range, Position, Error, VERSION, MOBILEDOC_VERSION, DOMParser, PostNodeBuilder, mobiledocRenderers }


### PR DESCRIPTION
Add exports to allow to build additional use-cases on top of mobiledoc-kit. Left comment https://github.com/bustle/mobiledoc-kit/pull/710#issuecomment-822427552 and realized that it seems to be possible to add more exports. 

This 3 exports should cover re-exports here in TryGhost - https://github.com/TryGhost/SDK/blob/main/packages/html-to-mobiledoc/lib/converter.js#L1 and this is something we also use in the similar fashion.

I am open for comments how to better approach this if this is not the way to re-export this internal bits.