### PR TITLE
Export modules useful for HTML processing

### DIFF
--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -5,6 +5,8 @@ import Range from './utils/cursor/range'
 import Position from './utils/cursor/position'
 import Error from './utils/mobiledoc-error'
 import VERSION from './version'
-import { MOBILEDOC_VERSION } from './renderers/mobiledoc'
+import Renderer, { MOBILEDOC_VERSION } from './renderers/mobiledoc'
+import DOMParser from './parsers/dom'
+import PostNodeBuilder from './models/post-node-builder'
 
-export { Editor, UI, ImageCard, Range, Position, Error, VERSION, MOBILEDOC_VERSION }
+export { Editor, UI, ImageCard, Range, Position, Error, DOMParser, PostNodeBuilder, Renderer, VERSION, MOBILEDOC_VERSION }


### PR DESCRIPTION
Very similar to https://github.com/bustle/mobiledoc-kit/pull/755, but I thought `Renderer` is perhaps more in keeping with the pattern of these exports.

With these three modules working together, I can process HTML to Mobiledoc with the following pattern:
```javascript
import { DOMParser, PostNodeBuilder as Builder, Renderer } from 'mobiledoc-kit'
import { JSDOM } from 'jsdom'

const html = "<h1>Hello, world</h1>"
const dom = new JSDOM(html)
const parser = new DOMParser(new Builder())
const post = parser.parse(dom.window.document.body)
Renderer.render(post, '0.3.2')
```