### PR TITLE
Fix emoji input on iOS

### DIFF
--- a/src/js/utils/key.ts
+++ b/src/js/utils/key.ts
@@ -89,7 +89,7 @@ export default class Key {
     if (this.isTab()) {
       return TAB
     }
-    return String.fromCharCode(this.charCode)
+    return String.fromCodePoint(this.charCode)
   }
 
   // See https://caniuse.com/#feat=keyboardevent-key for browser support.

--- a/tests/unit/utils/key-test.js
+++ b/tests/unit/utils/key-test.js
@@ -75,3 +75,15 @@ test('uses keyCode as a fallback if key is not supported', assert => {
   keyInstance = Key.fromEvent(event)
   assert.ok(keyInstance.isSpace(), 'keyCode is used if key is not supported')
 })
+
+test('properly handles UTF-16 characters', assert => {
+  let element = $('#qunit-fixture')[0]
+
+  let event = Helpers.dom.createMockEvent('keypress', element, {
+    key: '😀',
+    keyCode: 128512,
+    charCode: 128512,
+  })
+  let keyInstance = Key.fromEvent(event)
+  assert.equal('😀', keyInstance.toString(), 'emoji was not properly decoded')
+})


### PR DESCRIPTION
Many emoji char codes are bigger than String.fromCharCode() supports. String.fromCodePoint() has a larger range that allows emojis.

Fixes TryGhost/Ghost#11541.