### PR TITLE
Add css in "exports" section of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,13 @@
   "module": "dist/mobiledoc.js",
   "main": "dist/mobiledoc.cjs",
   "exports": {
-    "import": "./dist/mobiledoc.js",
-    "require": "./dist/mobiledoc.cjs"
+    ".": {
+      "import": "./dist/mobiledoc.js",
+      "require": "./dist/mobiledoc.cjs"
+    },
+    "./styles.css": {
+      "style": "./dist/mobiledoc.css"
+    }
   },
   "scripts": {
     "start": "rollup -c --watch",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "repository": "https://github.com/bustle/mobiledoc-kit",
   "module": "dist/mobiledoc.js",
   "main": "dist/mobiledoc.cjs",
+  "style": "dist/mobiledoc.css",
   "exports": {
     ".": {
       "import": "./dist/mobiledoc.js",
       "require": "./dist/mobiledoc.cjs"
     },
-    "./styles.css": {
+    "./style.css": {
       "style": "./dist/mobiledoc.css"
     }
   },


### PR DESCRIPTION
Declare `mobiledoc.css`as an export of mobiledoc-kit library to ease import of css in ESM environment.