### PR TITLE
Export MobiledocParser and utils functions to support extensibility

### DIFF
--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -8,6 +8,9 @@ import Error from './utils/mobiledoc-error'
 import Renderer, { MOBILEDOC_VERSION } from './renderers/mobiledoc'
 import DOMParser from './parsers/dom'
 import PostNodeBuilder from './models/post-node-builder'
+import MobiledocParser from './parsers/mobiledoc'
+import { parsePostFromHTML, parsePostFromText } from './utils/parse-utils'
+import { detect } from './utils/array-utils'
 
 export {
   Editor,
@@ -18,7 +21,11 @@ export {
   Markup,
   Error,
   DOMParser,
+  MobiledocParser,
   PostNodeBuilder,
   Renderer,
   MOBILEDOC_VERSION,
+  detect,
+  parsePostFromHTML,
+  parsePostFromText,
 }

--- a/src/js/utils/parse-utils.ts
+++ b/src/js/utils/parse-utils.ts
@@ -19,7 +19,7 @@ const MOBILEDOC_REGEX = new RegExp(/data-mobiledoc='(.*?)'>/)
  * @return {Post}
  * @private
  */
-function parsePostFromHTML(html: string, builder: PostNodeBuilder, plugins: SectionParserPlugin[]): Post {
+export function parsePostFromHTML(html: string, builder: PostNodeBuilder, plugins: SectionParserPlugin[]): Post {
   let post: Post
 
   if (MOBILEDOC_REGEX.test(html)) {
@@ -37,7 +37,7 @@ function parsePostFromHTML(html: string, builder: PostNodeBuilder, plugins: Sect
  * @return {Post}
  * @private
  */
-function parsePostFromText(text: string, builder: PostNodeBuilder, plugins: SectionParserPlugin[]): Post {
+export function parsePostFromText(text: string, builder: PostNodeBuilder, plugins: SectionParserPlugin[]): Post {
   let parser = new TextParser(builder, { plugins })
   let post = parser.parse(text)
   return post


### PR DESCRIPTION
Our use case for these additional exports is as follows:

MobiledocParser: we use it in a "cleaning" service that processes mobiledoc before saving to remove cards that have been added but not configured and so are effectively empty and should be removed.

parsePostFromHTML: we use it to let users convert older HTML content to mobiledoc, and in our tests to allow succinct creation of mobiledoc from HTML 

parsePostFromText: we use it to convert text from a CSV import into mobiledoc for further editing in our UI 

detect: we use it to find link markups in a mobiledoc to facilitate selection expansion when replacing a link